### PR TITLE
microsoftedge: Add version 83.0.478.61

### DIFF
--- a/bucket/microsoftedge.json
+++ b/bucket/microsoftedge.json
@@ -1,22 +1,20 @@
 {
     "homepage": "https://www.microsoft.com/en-us/edge",
     "description": "See what's new on the latest version of the Microsoft Edge browser.",
-    "version": "79.0.309.71",
+    "version": "80.0.361.103",
     "license": "Freeware",
     "architecture": {
         "64bit": {
             "url": "https://api.shuax.com/v2/download/edge/stable/x64#/dl.7z",
-            "hash": "73b4bca09a2a69dece6eb78f35f42c692a4642ede5e38bd6bb28b68700390669"
+            "hash": "80d56f6fc2a49f0742be6063a22df18c73a4545c843e162ee95a780389380a15"
         },
         "32bit": {
             "url": "https://api.shuax.com/v2/download/edge/stable/x86#/dl.7z",
-            "hash": "f00e7acfb40198d9c0066156cbcd5f221bbb2249e0edf3f29eb378508cab5660"
+            "hash": "4f5f135e93c7856664e63c23f1c894665d133f2e875629edf0c358bd27f219a6"
         }
     },
     "installer": {
-        "script": [
-            "Expand-7zipArchive -Path \"$dir\\MSEDGE.7z\" -ExtractDir \"Chrome-bin\" -Removal"
-        ]
+        "script": "Expand-7zipArchive -Path \"$dir\\MSEDGE.7z\" -ExtractDir \"Chrome-bin\" -Removal"
     },
     "shortcuts": [
         [

--- a/bucket/microsoftedge.json
+++ b/bucket/microsoftedge.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://www.microsoft.com/en-us/edge",
     "description": "See what's new on the latest version of the Microsoft Edge browser.",
-    "version": "80.0.361.103",
+    "version": "81.0.416.64",
     "license": "Freeware",
     "architecture": {
         "64bit": {
             "url": "https://api.shuax.com/v2/download/edge/stable/x64#/dl.7z",
-            "hash": "80d56f6fc2a49f0742be6063a22df18c73a4545c843e162ee95a780389380a15"
+            "hash": "fa900445d4a8c87d8f2b71b00f23d9770fc1ffec7772104237cde3ed3ba37e51"
         },
         "32bit": {
             "url": "https://api.shuax.com/v2/download/edge/stable/x86#/dl.7z",
-            "hash": "4f5f135e93c7856664e63c23f1c894665d133f2e875629edf0c358bd27f219a6"
+            "hash": "087748ca5855061cbf2df161c68ed64c561449fc5831a38a53f694c26a4c081f"
         }
     },
     "installer": {

--- a/bucket/microsoftedge.json
+++ b/bucket/microsoftedge.json
@@ -1,0 +1,41 @@
+{
+    "homepage": "https://www.microsoft.com/en-us/edge",
+    "description": "See what's new on the latest version of the Microsoft Edge browser.",
+    "version": "79.0.309.71",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://api.shuax.com/v2/download/edge/stable/x64#/dl.7z",
+            "hash": "73b4bca09a2a69dece6eb78f35f42c692a4642ede5e38bd6bb28b68700390669"
+        },
+        "32bit": {
+            "url": "https://api.shuax.com/v2/download/edge/stable/x86#/dl.7z",
+            "hash": "f00e7acfb40198d9c0066156cbcd5f221bbb2249e0edf3f29eb378508cab5660"
+        }
+    },
+    "installer": {
+        "script": [
+            "Expand-7zipArchive -Path \"$dir\\MSEDGE.7z\" -ExtractDir \"Chrome-bin\" -Removal"
+        ]
+    },
+    "shortcuts": [
+        [
+            "msedge.exe",
+            "Microsoft Edge"
+        ]
+    ],
+    "checkver": {
+        "url": "http://scoop-services.azurewebsites.net/checkver?app=microsoftedge",
+        "jsonpath": "$.stable.x64.version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://api.shuax.com/v2/download/edge/stable/x64#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://api.shuax.com/v2/download/edge/stable/x86#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/microsoftedge.json
+++ b/bucket/microsoftedge.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://www.microsoft.com/en-us/edge",
-    "description": "See what's new on the latest version of the Microsoft Edge browser.",
-    "version": "81.0.416.64",
+    "description": "The chromium based Microsoft Edge browser",
+    "version": "83.0.478.61",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://api.shuax.com/v2/download/edge/stable/x64#/dl.7z",
-            "hash": "fa900445d4a8c87d8f2b71b00f23d9770fc1ffec7772104237cde3ed3ba37e51"
+            "url": "https://edge-dl.kidonng.workers.dev/https://api.shuax.com/v2/download/edge/stable/x64#/MicrosoftEdge-83.0.478.61-x86_x64.7z",
+            "hash": "288f1c837a6b1ae3bd4d6d0ad1633e485363d4cdc0de2c98070efc19dbedb53b"
         },
         "32bit": {
-            "url": "https://api.shuax.com/v2/download/edge/stable/x86#/dl.7z",
-            "hash": "087748ca5855061cbf2df161c68ed64c561449fc5831a38a53f694c26a4c081f"
+            "url": "https://edge-dl.kidonng.workers.dev/https://api.shuax.com/v2/download/edge/stable/x86#/MicrosoftEdge-83.0.478.61-x86.7z",
+            "hash": "9219cdd9419090e35f81d5dcd9ba3e8b1ee8bfddd75e514f13104b4060d9ecac"
         }
     },
     "installer": {
@@ -29,10 +29,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://api.shuax.com/v2/download/edge/stable/x64#/dl.7z"
+                "url": "https://edge-dl.kidonng.workers.dev/https://api.shuax.com/v2/download/edge/stable/x64#/MicrosoftEdge-$version-x86_x64.7z"
             },
             "32bit": {
-                "url": "https://api.shuax.com/v2/download/edge/stable/x86#/dl.7z"
+                "url": "https://edge-dl.kidonng.workers.dev/https://api.shuax.com/v2/download/edge/stable/x86#/MicrosoftEdge-$version-x86.7z"
             }
         }
     }

--- a/bucket/microsoftedge.json
+++ b/bucket/microsoftedge.json
@@ -25,7 +25,7 @@
         ]
     ],
     "checkver": {
-        "url": "http://scoop-services.azurewebsites.net/checkver?app=microsoftedge",
+        "url": "https://scoop-services.azurewebsites.net/checkver?app=microsoftedge",
         "jsonpath": "$.stable.x64.version"
     },
     "autoupdate": {


### PR DESCRIPTION
**WIP**

failed in PowerShell 6+, due to https://github.com/PowerShell/PowerShell/issues/2896
```
$ curl -X GET -I https://api.shuax.com/v2/download/edge/stable/x86
HTTP/1.1 307 Temporary Redirect
Server: nginx
Date: Sun, 02 Feb 2020 12:12:50 GMT
Content-Type: text/html; charset=UTF-8
Content-Length: 0
Connection: keep-alive
Location: http://msedge.f.tlu.dl.delivery.mp.microsoft.com/filestreamingservice/files/6aadba07-0e75-4d32-9302-217f397442dd?P1=1580731970&P2=402&P3=2&P4=ZLh8MNIdMlAi0b4VoMsUeNr%2bqgB4AXlHbT3%2bzJ%2fkuDNFQi2B%2bJidmzST80ufikrwf0ohJWoLkY0eL86zUaAu4w%3d%3d
Vary: Accept-Encoding
```

Solution: ~~change download API endpoint, or wait for PowerShell updates.~~ https://github.com/lukesampson/scoop/pull/3902

credit: the download endpoint is provided by https://tools.shuax.com/edge/ created by @shuax 
