### PR TITLE
bamboo: Add version 1.2.0

### DIFF
--- a/bucket/bamboo.json
+++ b/bucket/bamboo.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://christopherwk210.github.io/bamboo/",
+    "description": "Leverage the power of the TinyPNG API to optimize your images with smart lossy compression.",
+    "version": "1.2.0",
+    "license": "MIT",
+    "url": "https://github.com/christopherwk210/bamboo/releases/download/v1.2.0/bamboo-win32-ia32.zip",
+    "hash": "ed769b899ea84396bf2b6ae2848b1576280afd5cfd3f907513acdac1671a9e9a",
+    "extract_dir": "bamboo-win32-ia32",
+    "shortcuts": [
+        [
+            "bamboo.exe",
+            "Bamboo"
+        ]
+    ],
+    "checkver": "github"
+}

--- a/bucket/bamboo.json
+++ b/bucket/bamboo.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://christopherwk210.github.io/bamboo/",
-    "description": "Leverage the power of the TinyPNG API to optimize your images with smart lossy compression.",
+    "description": "A cross-platform TinyPNG client",
     "version": "1.2.0",
     "license": "MIT",
     "url": "https://github.com/christopherwk210/bamboo/releases/download/v1.2.0/bamboo-win32-ia32.zip",
@@ -12,5 +12,10 @@
             "Bamboo"
         ]
     ],
-    "checkver": "github"
+    "checkver": {
+        "github": "https://github.com/christopherwk210/bamboo"
+    },
+    "autoupdate": {
+        "url": "https://github.com/christopherwk210/bamboo/releases/download/v$version/bamboo-win32-ia32.zip"
+    }
 }


### PR DESCRIPTION
Bamboo allows you to use your TinyPNG API key to losslessly compress local PNG/JPG's on your computer.

This json has been successfully installed bamboo on my pc.
```
PS C:\Users\****> scoop install bamboo
WARN  Scoop uses 'aria2c' for multi-connection downloads.
WARN  Should it cause issues, run 'scoop config aria2-enabled false' to disable it.
Installing 'bamboo' (1.2.0) [64bit]
Loading bamboo-win32-ia32.zip from cache.
Checking hash of bamboo-win32-ia32.zip ... ok.
Extracting bamboo-win32-ia32.zip ... done.
Linking ~\scoop\apps\bamboo\current => ~\scoop\apps\bamboo\1.2.0
Creating shortcut for Bamboo (bamboo.exe)
'bamboo' (1.2.0) was installed successfully!
```
