### PR TITLE
utools: use checkver helper

### DIFF
--- a/bucket/utools.json
+++ b/bucket/utools.json
@@ -27,7 +27,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://resource.u-tools.cn/currentversion/public.yml?",
+        "url": "https://scoop-sushi.vercel.app/api/utools",
         "regex": "uTools-([\\w.-]+).exe"
     },
     "autoupdate": {


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/44045911/94677662-e25d5800-034f-11eb-8087-73704b99b108.png)

## Solution

I write [a checkver helper](https://github.com/kidonng/sushi/blob/master/api/utools.ts), basically it prevents updating to old versions.
You can deploy it on your own if you prefer.