### PR TITLE
clash-for-windows(-portable): add x86 architecture

### DIFF
--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -4,7 +4,7 @@
     "version": "0.13.0",
     "license": "MIT",
     "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
-    "hash": "ec69d7031714444a4654be462ac06f28d4945a978bb1de76d46e3b31e121f9a1",
+    "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7",
     "notes": [
         "Place provider files in \".\\providers\\\" directory to keep persisted",
         "Profiles and settings will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
@@ -100,7 +100,7 @@
         "hash": {
             "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
             "mode": "extract",
-            "regex": "exe: $sha256"
+            "regex": "^exe: $sha256"
         }
     }
 }

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -3,8 +3,16 @@
     "description": "A Windows GUI based on Clash",
     "version": "0.13.0",
     "license": "MIT",
-    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
-    "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
+            "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7"
+        },
+        "32bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.ia32.exe#/dl.7z",
+            "hash": "ec69d7031714444a4654be462ac06f28d4945a978bb1de76d46e3b31e121f9a1"
+        }
+    },
     "notes": [
         "Place provider files in \".\\providers\\\" directory to keep persisted",
         "Profiles and settings will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
@@ -96,11 +104,23 @@
     },
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.exe#/dl.7z",
-        "hash": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
-            "mode": "extract",
-            "regex": "^exe: $sha256"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "^exe: $sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.ia32.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "^ia32-exe: $sha256"
+                }
+            }
         }
     }
 }

--- a/bucket/clash-for-windows.json
+++ b/bucket/clash-for-windows.json
@@ -3,8 +3,16 @@
     "description": "A Windows GUI based on Clash",
     "version": "0.13.0",
     "license": "MIT",
-    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
-    "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
+            "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7"
+        },
+        "32bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.ia32.exe#/dl.7z",
+            "hash": "ec69d7031714444a4654be462ac06f28d4945a978bb1de76d46e3b31e121f9a1"
+        }
+    },
     "installer": {
         "script": [
             "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -19,11 +27,23 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.exe#/dl.7z",
-        "hash": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
-            "mode": "extract",
-            "regex": "^exe: $sha256"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "^exe: $sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.ia32.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "^ia32-exe: $sha256"
+                }
+            }
         }
     }
 }

--- a/bucket/clash-for-windows.json
+++ b/bucket/clash-for-windows.json
@@ -4,7 +4,7 @@
     "version": "0.13.0",
     "license": "MIT",
     "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
-    "hash": "ec69d7031714444a4654be462ac06f28d4945a978bb1de76d46e3b31e121f9a1",
+    "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7",
     "installer": {
         "script": [
             "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -23,7 +23,7 @@
         "hash": {
             "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
             "mode": "extract",
-            "regex": "exe: $sha256"
+            "regex": "^exe: $sha256"
         }
     }
 }


### PR DESCRIPTION
新增了x86支持。
另外作者说这个版本的便携版可能存在问题，预计下个版本修复，并且修改便携版配置文件目录及激活逻辑。