### PR TITLE
clash-for-windows-portable: adjust for new version

### DIFF
--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -55,6 +55,7 @@
     ],
     "uninstaller": {
         "script": [
+            "Get-Process -Name \"Clash for Windows\" | Stop-Process",
             "if (Test-Path \"$env:appdata\\clash_win\") {",
             "    Move-Item \"$env:appdata\\clash_win\" \"$persist_dir\" -Force",
             "}"

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -3,11 +3,20 @@
     "description": "A Windows GUI based on Clash",
     "version": "0.13.0",
     "license": "MIT",
-    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
-    "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
+            "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7"
+        },
+        "32bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.ia32.exe#/dl.7z",
+            "hash": "ec69d7031714444a4654be462ac06f28d4945a978bb1de76d46e3b31e121f9a1"
+        }
+    },
     "notes": [
-        "Place provider files in \".\\providers\\\" directory to keep persisted",
-        "Profiles and settings will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
+        "Since version 0.13.0, \"Clash for Windows\" uses \"data\" folder in app directory to active portable mode and store user config",
+        "Simply click \"Open Folder\" buttom in \"General\" tab of app GUI and then you will be there",
+        "Config files will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
     ],
     "shortcuts": [
         [
@@ -16,26 +25,7 @@
         ]
     ],
     "persist": [
-        [
-            "resources\\static\\files\\logs",
-            "logs"
-        ],
-        [
-            "resources\\static\\files\\profiles",
-            "profiles"
-        ],
-        [
-            "resources\\static\\files\\providers",
-            "providers"
-        ],
-        [
-            "resources\\static\\files\\cfw-settings.yaml",
-            "cfw-settings.yaml"
-        ],
-        [
-            "resources\\static\\files\\config.yaml",
-            "config.yaml"
-        ]
+        "data"
     ],
     "installer": {
         "script": [
@@ -47,48 +37,23 @@
         "if (Test-Path \"$persist_dir\\clash_win\") {",
         "    Move-Item \"$persist_dir\\clash_win\" \"$env:appdata\" -Force",
         "}",
-        "if (!(Test-Path \"$persist_dir\\config.yaml\")) {",
-        "    if (!(Test-Path \"$persist_dir\")) {",
-        "        New-Item \"$persist_dir\" -ItemType Directory -Force | Out-Null",
-        "    }",
-        "    if (Test-Path \"$HOME\\.config\\clash\\config.yaml\") {",
-        "        Write-Host 'Importing profiles and settings from user directory...' -ForegroundColor Yellow",
-        "        Remove-Item \"$persist_dir\\*\" -Force -Recurse",
-        "        New-Item \"$persist_dir\\providers\" -ItemType Directory -Force | Out-Null",
-        "        Copy-Item \"$HOME\\.config\\clash\\*.yaml\" \"$persist_dir\\providers\" -Force",
-        "        Copy-Item \"$HOME\\.config\\clash\\*\\*.yaml\" \"$persist_dir\\providers\" -Force",
-        "        Move-Item \"$persist_dir\\providers\\config.yaml\" \"$persist_dir\" -Force",
-        "        if (Test-Path \"$persist_dir\\providers\\cfw-settings.yaml\") {",
-        "            Move-Item \"$persist_dir\\providers\\cfw-settings.yaml\" \"$persist_dir\" -Force",
-        "        }",
-        "        if (Test-Path \"$HOME\\.config\\clash\\logs\") {",
-        "            Copy-Item \"$HOME\\.config\\clash\\logs\" \"$persist_dir\" -Force -Recurse",
-        "        }",
-        "        if (Test-Path \"$HOME\\.config\\clash\\profiles\") {",
-        "            Copy-Item \"$HOME\\.config\\clash\\profiles\" \"$persist_dir\" -Force -Recurse",
-        "        }",
-        "        Write-Host 'Import succeded' -ForegroundColor Green",
-        "        Write-Host 'Provider files with .yaml suffix are persisted in \".\\providers\\\" directory, please edit \"path\" field in profiles' -ForegroundColor Green",
-        "        Write-Host 'This version uses profiles in scoop directory, old files in user directory can be removed by running \"Remove-Item $HOME\\.config\\clash -Force -Recurse\"' -ForegroundColor Yellow",
-        "    }",
-        "    else {",
-        "        New-Item \"$persist_dir\\config.yaml\" | Out-Null",
+        "if (!(Test-Path \"$persist_dir\")) {",
+        "    New-Item \"$persist_dir\" -ItemType Directory -Force | Out-Null",
+        "    if (Test-Path \"$HOME\\.config\\clash\") {",
+        "        Write-Host 'Importing config files from user directory for first install...' -ForegroundColor Yellow",
+        "        Copy-Item \"$HOME\\.config\\clash\\*\" \"$persist_dir\" -Force -Recurse",
+        "        Write-Host 'Import succeded!' -ForegroundColor Yellow",
+        "        Write-Host 'Portable version uses config files in app directory, ones in user directory can be removed by running ' -NoNewline -ForegroundColor Yellow",
+        "        Write-Host '\"Remove-Item $HOME\\.config\\clash -Force -Recurse\"' -ForegroundColor Green",
         "    }",
         "}",
-        "if (!(Test-Path \"$persist_dir\\cfw-settings.yaml\")) {",
-        "    New-Item \"$persist_dir\\cfw-settings.yaml\" | Out-Null",
+        "if (!(Test-Path \"$persist_dir\\data\")) {",
+        "    New-Item \"$persist_dir\\data\" -ItemType Directory -Force | Out-Null",
+        "    Move-Item \"$persist_dir\\*\" \"$persist_dir\\data\" -Exclude \"$persist_dir\\data\" -Force -ErrorAction SilentlyContinue",
         "}"
     ],
     "uninstaller": {
         "script": [
-            "Remove-Item \"$persist_dir\\config.yaml\" -Force",
-            "Remove-Item \"$persist_dir\\cfw-settings.yaml\" -Force",
-            "if (Test-Path \"$dir\\resources\\static\\files\\config.yaml\") {",
-            "    Copy-Item \"$dir\\resources\\static\\files\\config.yaml\" \"$persist_dir\" -Force",
-            "    if (Test-Path \"$dir\\resources\\static\\files\\cfw-settings.yaml\") {",
-            "        Copy-Item \"$dir\\resources\\static\\files\\cfw-settings.yaml\" \"$persist_dir\" -Force",
-            "    }",
-            "}",
             "if (Test-Path \"$env:appdata\\clash_win\") {",
             "    Move-Item \"$env:appdata\\clash_win\" \"$persist_dir\" -Force",
             "}"
@@ -96,11 +61,23 @@
     },
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.exe#/dl.7z",
-        "hash": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
-            "mode": "extract",
-            "regex": "exe: $sha256"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "^exe: $sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.ia32.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "^ia32-exe: $sha256"
+                }
+            }
         }
     }
 }

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -55,7 +55,7 @@
     ],
     "uninstaller": {
         "script": [
-            "Get-Process -Name \"Clash for Windows\" | Stop-Process",
+            "Get-Process -Name \"Clash for Windows\" -ErrorAction SilentlyContinue | Stop-Process -Force",
             "if (Test-Path \"$env:appdata\\clash_win\") {",
             "    Move-Item \"$env:appdata\\clash_win\" \"$persist_dir\" -Force",
             "}"

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -38,7 +38,7 @@
         "    Move-Item \"$persist_dir\\clash_win\" \"$env:appdata\" -Force",
         "}",
         "if (!(Test-Path \"$persist_dir\")) {",
-        "    New-Item \"$persist_dir\" -ItemType Directory -Force | Out-Null",
+        "    New-Item \"$persist_dir\" -Type Directory -Force | Out-Null",
         "    if (Test-Path \"$HOME\\.config\\clash\") {",
         "        Write-Host 'Importing config files from user directory for first install...' -ForegroundColor Yellow",
         "        Copy-Item \"$HOME\\.config\\clash\\*\" \"$persist_dir\" -Force -Recurse",
@@ -48,8 +48,8 @@
         "    }",
         "}",
         "if (!(Test-Path \"$persist_dir\\data\")) {",
-        "    New-Item \"$persist_dir\\data\" -ItemType Directory -Force | Out-Null",
-        "    Move-Item \"$persist_dir\\*\" \"$persist_dir\\data\" -Exclude \"$persist_dir\\data\" -Force -ErrorAction SilentlyContinue",
+        "    New-Item \"$persist_dir\\data\" -Type Directory -Force | Out-Null",
+        "    Get-ChildItem \"$persist_dir\" -Exclude \"data\" | Move-Item -Destination \"$persist_dir\\data\" -Force",
         "}"
     ],
     "uninstaller": {

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -55,7 +55,7 @@
     ],
     "uninstaller": {
         "script": [
-            "Get-Process -Name \"Clash for Windows\" -ErrorAction SilentlyContinue | Stop-Process -Force",
+            "Get-Process | Where-Object {$_.Name -eq \"Clash for Windows\"} | Stop-Process -Force",
             "if (Test-Path \"$env:appdata\\clash_win\") {",
             "    Move-Item \"$env:appdata\\clash_win\" \"$persist_dir\" -Force",
             "}"

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -15,7 +15,7 @@
     },
     "notes": [
         "Since version 0.13.0, \"Clash for Windows\" uses \"data\" folder in app directory to active portable mode and store user config",
-        "Simply click \"Open Folder\" buttom in \"General\" tab of app GUI and then you will be there",
+        "Simply click \"Open Folder\" button in \"General\" tab of app GUI and then you will be there",
         "Config files will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
     ],
     "shortcuts": [

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -1,20 +1,20 @@
 {
     "homepage": "https://github.com/Fndroid/clash_for_windows_pkg",
     "description": "A Windows GUI based on Clash",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.exe#/dl.7z",
-            "hash": "325341a6cd2d74e645b2963bbdcea21eeddba471e3d9fbea9eef7fb2991c4bb7"
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.1/Clash.for.Windows.Setup.0.13.1.exe#/dl.7z",
+            "hash": "8ff7c72573fb8c2c620d815e6d7531825f7bd8fdfcae0fe135b7825150f6fdf9"
         },
         "32bit": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.0/Clash.for.Windows.Setup.0.13.0.ia32.exe#/dl.7z",
-            "hash": "ec69d7031714444a4654be462ac06f28d4945a978bb1de76d46e3b31e121f9a1"
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.1/Clash.for.Windows.Setup.0.13.1.ia32.exe#/dl.7z",
+            "hash": "42810808b43605060d218cb4a16a6258b17e8edd4d78aa000121e31383942f05"
         }
     },
     "notes": [
-        "Since version 0.13.0, \"Clash for Windows\" uses \"data\" folder in app directory to active portable mode and store user config",
+        "Since version 0.13.1, \"Clash for Windows\" uses \"data\" folder in app directory to active portable mode and store user config",
         "Simply click \"Open Folder\" button in \"General\" tab of app GUI and then you will be there",
         "Config files will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
     ],

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -43,14 +43,15 @@
         "        Write-Host 'Importing config files from user directory for first install...' -ForegroundColor Yellow",
         "        Copy-Item \"$HOME\\.config\\clash\\*\" \"$persist_dir\" -Force -Recurse",
         "        Write-Host 'Import succeded!' -ForegroundColor Yellow",
-        "        Write-Host 'Portable version uses config files in app directory, ones in user directory can be removed by running ' -NoNewline -ForegroundColor Yellow",
-        "        Write-Host '\"Remove-Item $HOME\\.config\\clash -Force -Recurse\"' -ForegroundColor Green",
+        "        Write-Host 'Portable version uses config files in app directory, ones in user directory can be removed by running' -ForegroundColor Yellow",
+        "        Write-Host 'Remove-Item \"$HOME\\.config\\clash\" -Force -Recurse' -ForegroundColor Green",
         "    }",
         "}",
         "if (!(Test-Path \"$persist_dir\\data\")) {",
         "    New-Item \"$persist_dir\\data\" -Type Directory -Force | Out-Null",
         "    Get-ChildItem \"$persist_dir\" -Exclude \"data\" | Move-Item -Destination \"$persist_dir\\data\" -Force",
-        "}"
+        "}",
+        "Get-ChildItem \"$persist_dir\\data\" -Filter \"Country.mmdb\" | Remove-Item -Force"
     ],
     "uninstaller": {
         "script": [

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -55,7 +55,6 @@
     ],
     "uninstaller": {
         "script": [
-            "Get-Process | Where-Object {$_.Name -eq \"Clash for Windows\"} | Stop-Process -Force",
             "if (Test-Path \"$env:appdata\\clash_win\") {",
             "    Move-Item \"$env:appdata\\clash_win\" \"$persist_dir\" -Force",
             "}"

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://github.com/Fndroid/clash_for_windows_pkg",
     "description": "A Windows GUI based on Clash",
-    "version": "0.13.1",
+    "version": "0.13.2",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.1/Clash.for.Windows.Setup.0.13.1.exe#/dl.7z",
-            "hash": "8ff7c72573fb8c2c620d815e6d7531825f7bd8fdfcae0fe135b7825150f6fdf9"
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.2/Clash.for.Windows.Setup.0.13.2.exe#/dl.7z",
+            "hash": "3693ba5cb87eeea5d3030920b6c88ff4f1f2ef6669b9c2105466884da28af51c"
         },
         "32bit": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.1/Clash.for.Windows.Setup.0.13.1.ia32.exe#/dl.7z",
-            "hash": "42810808b43605060d218cb4a16a6258b17e8edd4d78aa000121e31383942f05"
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.2/Clash.for.Windows.Setup.0.13.2.ia32.exe#/dl.7z",
+            "hash": "52ea27aab147e3baeeba57eda0bb465dab631c9930a97bfb8ede89882c633624"
         }
     },
     "notes": [

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -14,7 +14,7 @@
         }
     },
     "notes": [
-        "Since version 0.13.1, \"Clash for Windows\" uses \"data\" folder in app directory to active portable mode and save user config",
+        "Since version 0.13.1, Clash for Windows uses \"data\" folder in app directory to active portable mode and save user config",
         "Simply click \"Open Folder\" button in \"General\" page and then you will be there",
         "Config files will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
     ],

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -14,8 +14,8 @@
         }
     },
     "notes": [
-        "Since version 0.13.1, \"Clash for Windows\" uses \"data\" folder in app directory to active portable mode and store user config",
-        "Simply click \"Open Folder\" button in \"General\" tab of app GUI and then you will be there",
+        "Since version 0.13.1, \"Clash for Windows\" uses \"data\" folder in app directory to active portable mode and save user config",
+        "Simply click \"Open Folder\" button in \"General\" page and then you will be there",
         "Config files will be permanently removed by running \"scoop uninstall -p clash-for-windows-portable\" while uninstalling"
     ],
     "shortcuts": [

--- a/bucket/clash-for-windows-portable.json
+++ b/bucket/clash-for-windows-portable.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://github.com/Fndroid/clash_for_windows_pkg",
     "description": "A Windows GUI based on Clash",
-    "version": "0.13.2",
+    "version": "0.13.3",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.2/Clash.for.Windows.Setup.0.13.2.exe#/dl.7z",
-            "hash": "3693ba5cb87eeea5d3030920b6c88ff4f1f2ef6669b9c2105466884da28af51c"
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.3/Clash.for.Windows.Setup.0.13.3.exe#/dl.7z",
+            "hash": "4169514e05f2f9680e11554fd400a23daab56b1a4736a99d615134d778ca19ae"
         },
         "32bit": {
-            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.2/Clash.for.Windows.Setup.0.13.2.ia32.exe#/dl.7z",
-            "hash": "52ea27aab147e3baeeba57eda0bb465dab631c9930a97bfb8ede89882c633624"
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.13.3/Clash.for.Windows.Setup.0.13.3.ia32.exe#/dl.7z",
+            "hash": "3c3cb711ac90767ecb914dcbbe39577c9945e3690a78bf72e993a031c91d9e63"
         }
     },
     "notes": [


### PR DESCRIPTION
适配新版的文件目录和判断逻辑：
新版本中CFW使用应用目录下的``data``文件夹触发portable mode并存储用户配置