### PR TITLE
texlive: hash fix

### DIFF
--- a/bucket/texlive.json
+++ b/bucket/texlive.json
@@ -4,7 +4,7 @@
     "license": "LPPL,GPL2",
     "version": "2021",
     "url": "http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip",
-    "hash": "sha512:50f16435efad2ba4099dc11532b7a0df8140e2684c527046b76b823f69f8758125f7570e2a39d0475da0900053d157eca6951cd15626c7465ab2baa3f717c9ff",
+    "hash": "sha512:f9c286e3540f8ba190a0d8b444887de25bef52f339a49e54c80c6452e972c1cbc024b956eee96f85181613685eda1886fc4d555924c0fe013f98ceb9197a0e1f",
     "installer": {
         "script": [
             "Write-Host 'Invoking TeX Live installer...' -ForegroundColor DarkCyan",


### PR DESCRIPTION
- [x] update sha512 for texlive
sha512 come from the .sha512 file
