### PR TITLE
picgo: update picgo download url

### DIFF
--- a/bucket/picgo.json
+++ b/bucket/picgo.json
@@ -13,7 +13,7 @@
         },
         "32bit": {
             "url": "https://github.com/Molunerfinn/PicGo/releases/download/v2.3.0/picgo-setup-2.3.0-ia32.exe#/dl.7z",
-            "hash": "78cbd6ea2618777f369304120cd8d7341f960017a89e5e017f9430a7a3c6d41c"
+            "hash": "sha512:c81ec09a612de90c3982dc508ed81620702c577a3288fa15adf71dea0adee7fe36f30f92ed4a1a5a64d5c971fac68f603bd1cd4e551c3adf742360c4da16bc0e"
         }
     },
     "installer": {
@@ -36,16 +36,16 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/picgo-setup-$version-x64.exe#/dl.7z",
-                "hash": {
-                    "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/latest.yml",
-                    "mode": "extract",
-                    "regex": "(?sm)exe.*sha512: $base64"
-                }
+                "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/picgo-setup-$version-x64.exe#/dl.7z"
             },
             "32bit": {
                 "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/picgo-setup-$version-ia32.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/latest.yml",
+            "mode": "extract",
+            "regex": "(?sm)exe.*sha512: $base64"
         }
     }
 }

--- a/bucket/picgo.json
+++ b/bucket/picgo.json
@@ -6,8 +6,16 @@
         "identifier": "996ICU",
         "url": "https://github.com/Molunerfinn/PicGo/blob/dev/LICENSE"
     },
-    "url": "https://github.com/Molunerfinn/PicGo/releases/download/v2.3.0/picgo-setup-2.3.0.exe#/dl.7z",
-    "hash": "sha512:c81ec09a612de90c3982dc508ed81620702c577a3288fa15adf71dea0adee7fe36f30f92ed4a1a5a64d5c971fac68f603bd1cd4e551c3adf742360c4da16bc0e",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Molunerfinn/PicGo/releases/download/v2.3.0/picgo-setup-2.3.0-x64.exe#/dl.7z",
+            "hash": "sha512:c81ec09a612de90c3982dc508ed81620702c577a3288fa15adf71dea0adee7fe36f30f92ed4a1a5a64d5c971fac68f603bd1cd4e551c3adf742360c4da16bc0e"
+        },
+        "32bit": {
+            "url": "https://github.com/Molunerfinn/PicGo/releases/download/v2.3.0/picgo-setup-2.3.0-ia32.exe#/dl.7z",
+            "hash": "78cbd6ea2618777f369304120cd8d7341f960017a89e5e017f9430a7a3c6d41c"
+        }
+    },
     "installer": {
         "script": [
             "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -26,11 +34,18 @@
         "regex": "releases/tag/v([\\d.]+)\""
     },
     "autoupdate": {
-        "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/picgo-setup-$version.exe#/dl.7z",
-        "hash": {
-            "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/latest.yml",
-            "mode": "extract",
-            "regex": "(?sm)exe.*sha512: $base64"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/picgo-setup-$version-x64.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/latest.yml",
+                    "mode": "extract",
+                    "regex": "(?sm)exe.*sha512: $base64"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/Molunerfinn/PicGo/releases/download/v$version/picgo-setup-$version-ia32.exe#/dl.7z"
+            }
         }
     }
 }


### PR DESCRIPTION
[Picgo](https://github.com/Molunerfinn/PicGo) added ia32(x86) version in the recent stable release [build.](https://github.com/Molunerfinn/PicGo/releases/tag/v2.3.0)

The naming rule has changed too! 
[`PicGo-Setup-2.3.0-x64.exe`](https://github.com/Molunerfinn/PicGo/releases/download/v2.3.0/PicGo-Setup-2.3.0-x64.exe) and [`PicGo-Setup-2.3.0-ia32.exe`](https://github.com/Molunerfinn/PicGo/releases/download/v2.3.0/PicGo-Setup-2.3.0-ia32.exe) are the installer files in the release asserts now.


In this pr
-  I added both x86 and x64 versions. 
- Since the hash of the x86 version is not in the [yaml](https://github.com/Molunerfinn/PicGo/releases/download/v2.3.0/latest.yml) file. I left it for scoop to calculate.
- The x64 version used the old way to extract the hash from the yaml file.


By the way, I am a newbie pull requester, if there is something wrong please help correct the changed files or let me know.
fix #400 
