### PR TITLE
macast: Add version 0.65

### DIFF
--- a/bucket/macast.json
+++ b/bucket/macast.json
@@ -1,6 +1,6 @@
 {
     "version": "0.65",
-    "description": "A menu bar application using mpv as DLNA Media Renderer. You can push videos, pictures or musics from your mobile phone to your computer.",
+    "description": "A menu bar application using mpv as DLNA Media Renderer",
     "homepage": "https://xfangfang.github.io/Macast",
     "license": "GPL-3.0-only",
     "architecture": {
@@ -21,7 +21,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/zodiacon/RegExp/releases/download/v$version/Macast-Windows-v$version.exe#/Macast.exe"
+                "url": "https://github.com/xfangfang/Macast/releases/download/v$version/Macast-Windows-v$version.exe#/Macast.exe"
             }
         }
     }


### PR DESCRIPTION
A menu bar application using mpv as **DLNA Media Renderer**. You can push videos, pictures or musics from your mobile phone to your computer.

Macast是一个跨平台的 **菜单栏\状态栏** 应用，用户可以使用电脑接收发送自手机的视频、图片和音乐，支持主流视频音乐软件和其他任何符合DLNA协议的投屏软件。