### PR TITLE
fix(go-cn): fix the update for go-cn

### DIFF
--- a/bucket/go-cn.json
+++ b/bucket/go-cn.json
@@ -34,7 +34,7 @@
     "persist": "global_path",
     "checkver": {
         "url": "https://golang.google.cn/dl/",
-        "regex": "go([\\d.]+)\\."
+        "regex": "go([\\d.]+)\\.windows-"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
参照main库的go对go-cn的update checker进行完善，保证其更新的正常可用，不然go版本不是最新