### PR TITLE
winlibs-mingw-ucrt: Fix description

### DIFF
--- a/bucket/winlibs-mingw-llvm-ucrt.json
+++ b/bucket/winlibs-mingw-llvm-ucrt.json
@@ -17,7 +17,7 @@
     },
     "env_add_path": "bin",
     "checkver": {
-        "regex": "/download/(?<version>((?<gccVersion>11[\\d.]+)(-(?<llvmVersion>[\\d.]+))?-(?<mingwVersion>[\\d.]+)-ucrt(-(?<revision>[\\w]+))?))"
+        "regex": "/download/(?<version>((?<gccVersion>11[\\d.]+)-(?<llvmVersion>[\\d.]+)-(?<mingwVersion>[\\d.]+)-ucrt(-(?<revision>[\\w]+))?))"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/winlibs-mingw-snapshot.json
+++ b/bucket/winlibs-mingw-snapshot.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://winlibs.com/",
-    "description": "winlibs standalone build of GCC compiler and MinGW-w64 (Snapshot versions)",
+    "description": "winlibs standalone build of GCC compiler and MinGW-w64 with MSVCRT (Snapshot versions)",
     "version": "11.2.1-9.0.0-snapshot20210814-r1",
     "license": "GPL-2.0-only,BSD-2-Clause,Apache-2.0,ZPL-2.1",
     "architecture": {

--- a/bucket/winlibs-mingw-ucrt.json
+++ b/bucket/winlibs-mingw-ucrt.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://winlibs.com/",
-    "description": "winlibs standalone build of GCC compiler and MinGW-w64 with llvm",
+    "description": "winlibs standalone build of GCC compiler and MinGW-w64 with UCRT",
     "version": "11.2.0-13.0.0-9.0.0-ucrt-r2",
     "license": "GPL-2.0-only,BSD-2-Clause,Apache-2.0,ZPL-2.1",
     "architecture": {

--- a/bucket/winlibs-mingw.json
+++ b/bucket/winlibs-mingw.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://winlibs.com/",
-    "description": "winlibs standalone build of GCC compiler and MinGW-w64",
+    "description": "winlibs standalone build of GCC compiler and MinGW-w64 with MSVCRT",
     "version": "11.2.0-12.0.1-9.0.0-r1",
     "license": "GPL-2.0-only,BSD-2-Clause,Apache-2.0,ZPL-2.1",
     "architecture": {


### PR DESCRIPTION
As mentioned here https://github.com/chawyehsu/dorado/pull/439#discussion_r746252730, this pr do a minor fix on winlibs description.
As well as made llvm version be mandatory at the checkver regex configuration of winlibs-mingw-llvm-ucrt.