### PR TITLE
miniconda3: Update to version 4.10.3

### DIFF
--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -1,16 +1,16 @@
 {
-    "version": "4.9.2",
+    "version": "4.10.3",
     "homepage": "https://conda.io/miniconda.html",
     "description": "Miniconda is a free minimal installer for conda.",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://repo.continuum.io/miniconda/Miniconda3-py39_4.9.2-Windows-x86_64.exe",
-            "hash": "md5:1ca0befe028325a766be4e3e0727b945"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Windows-x86_64.exe",
+            "hash": "md5:128f0ca2c55441bffdb68d1e98f5b481"
         },
         "32bit": {
-            "url": "https://repo.continuum.io/miniconda/Miniconda3-py39_4.9.2-Windows-x86.exe",
-            "hash": "md5:36cbe3b9a2933efa4ed71bb286368673"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.10.3-Windows-x86.exe",
+            "hash": "md5:a082be7ef6dd4f14b974dab2d78c5693"
         }
     },
     "installer": {
@@ -34,17 +34,16 @@
         "conda config --system --set auto_activate_base false"
     ],
     "checkver": {
-        "url": "https://repo.continuum.io/miniconda",
-        "re": "Miniconda3-py(?<pyversion>[\\d]+)_([\\d.]+)-Windows",
-        "reverse": true
+        "url": "https://docs.conda.io/en/latest/miniconda.html",
+        "re": "Miniconda3-py(?<pyversion>[\\d]+)_([\\d.]+)-Windows"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repo.continuum.io/miniconda/Miniconda3-py$matchPyversion_$version-Windows-x86_64.exe"
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py$matchPyversion_$version-Windows-x86_64.exe"
             },
             "32bit": {
-                "url": "https://repo.continuum.io/miniconda/Miniconda3-py$matchPyversion_$version-Windows-x86.exe"
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py$matchPyversion_$version-Windows-x86.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20319256/141676493-80440b92-f7e2-4577-b046-c1815f2aea2a.png)

In the <https://repo.continuum.io/miniconda>, `4.10.3` comes before `4.9.2`


- I modified `checkver` and `autoupdate.url` referring to [extra/miniconda3](https://github.com/ScoopInstaller/Extras/blob/master/bucket/miniconda3.json)
- Default channels point to `repo.anaconda.com` instead of `repo.continuum.io`
https://github.com/conda/conda/issues/6886

![image](https://user-images.githubusercontent.com/20319256/141676625-7c57283a-fed0-4153-b423-6bba25884bba.png)