### PR TITLE
qbittorrent-enhanced: Update to version 4.4.1.10

### DIFF
--- a/bucket/qbittorrent-enhanced.json
+++ b/bucket/qbittorrent-enhanced.json
@@ -4,16 +4,16 @@
         "identifier": "GPL-2.0-only",
         "url": "https://github.com/qbittorrent/qBittorrent/blob/master/COPYING"
     },
-    "version": "4.4.0.10",
+    "version": "4.4.1.10",
     "description": "qBittorrent BitTorrent client with anti-leech enhancement.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.0.10/qbittorrent_enhanced_4.4.0.10_x64_setup.exe#/dl.7z",
-            "hash": "721055eab10962565f475dce88d1a2b4f58abfbc95b19197d94da4a15d5c1ddd"
+            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.1.10/qbittorrent_enhanced_4.4.1.10_Qt5_x64_setup.exe#/dl.7z",
+            "hash": "e6c0022b8abf600d4538ca58a73d0f4c419b6460520c243eebe57d82320b2254"
         },
         "32bit": {
-            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.0.10/qbittorrent_enhanced_4.4.0.10_setup.exe#/dl.7z",
-            "hash": "3f1587f12cdd85e49d030d2bf912267bebb5c758915d7419ee84645b3120e057"
+            "url": "https://github.com/c0re100/qBittorrent-Enhanced-Edition/releases/download/release-4.4.1.10/qbittorrent_enhanced_4.4.1.10_setup.exe#/dl.7z",
+            "hash": "98f8de01fce499f5e8b92da06ad7eb3f7fc8b480bf3d64d777d584e49e07748b"
         }
     },
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",


### PR DESCRIPTION
An issue that may be discussed is that the new version releases the Qt5 and Qt6 versions for x64. I don't know whether it will release like this in further versions. So I didn't change the URL in autoupdate.