### PR TITLE
64Gram: Add version 1.0.34

### DIFF
--- a/bucket/64Gram.json
+++ b/bucket/64Gram.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.0.34",
+    "description": "Unofficial Telegram Desktop (Windows 64bit/x64)",
+    "homepage": "https://64gr.am",
+    "license": {
+        "identifier": "GPL-3.0-with-OpenSSL-exception",
+        "url": "https://github.com/TDesktop-x64/tdesktop/blob/dev/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TDesktop-x64/tdesktop/releases/download/v1.0.34/64Gram_1.0.34_x64.zip",
+            "hash": "2016a8842ab0347ab5494b110a204805447a0ddc0a57a7e12b9b564db253e30c"
+        },
+        "32bit": {
+            "url": "https://github.com/TDesktop-x64/tdesktop/releases/download/v1.0.34/64Gram_1.0.34_x86.zip",
+            "hash": "e97f70516e0a619af57ca7a54ae8d370311c7fa762b84c22b156a733ffaf0207"
+        }
+    },
+    "persist": "tdata",
+    "bin": "Telegram.exe",
+    "shortcuts": [
+        [
+            "Telegram.exe",
+            "64Gram"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/TDesktop-x64/tdesktop"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TDesktop-x64/tdesktop/releases/download/v$version/64Gram_$version_x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/TDesktop-x64/tdesktop/releases/download/v$version/64Gram_$version_x86.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added manifest:

[64Gram](https://github.com/TDesktop-x64/tdesktop): Unofficial Telegram Desktop (Windows 64bit/x64).