### PR TITLE
snipaste-beta: fix backup file error

### DIFF
--- a/bucket/snipaste-beta.json
+++ b/bucket/snipaste-beta.json
@@ -26,10 +26,10 @@
     "uninstaller": {
         "script": [
             "function BackupFile([String] $file) {",
-            "    if (!(Test-Path \"$persist_dir\\$file\")) {",
+            "    if (Test-Path \"$persist_dir\\$file\") {",
             "        Remove-Item \"$persist_dir\\$file\" -Force",
             "    }",
-            "    Move-Item \"$dir\\$file\" \"$persist_dir\" -Force",
+            "    Copy-Item \"$dir\\$file\" \"$persist_dir\" -Force",
             "}",
             "BackupFile 'config.ini'"
         ]
@@ -41,6 +41,7 @@
         ]
     ],
     "persist": [
+        "crashes",
         "history",
         "config.ini"
     ],

--- a/bucket/snipaste-beta.json
+++ b/bucket/snipaste-beta.json
@@ -20,7 +20,8 @@
             "        New-Item -Force -Path \"$persist_dir\\$file\" -ItemType file -Value $content | Out-Null",
             "    }",
             "}",
-            "CreateFile 'config.ini'"
+            "CreateFile 'config.ini'",
+            "CreateFile 'splog.txt"
         ]
     },
     "uninstaller": {
@@ -31,7 +32,8 @@
             "    }",
             "    Copy-Item \"$dir\\$file\" \"$persist_dir\" -Force",
             "}",
-            "BackupFile 'config.ini'"
+            "BackupFile 'config.ini'",
+            "BackupFile 'splog.txt'"
         ]
     },
     "shortcuts": [
@@ -43,7 +45,8 @@
     "persist": [
         "crashes",
         "history",
-        "config.ini"
+        "config.ini",
+        "splog.txt"
     ],
     "suggest": {
         "vcredist": "extras/vcredist2015"

--- a/bucket/snipaste-beta.json
+++ b/bucket/snipaste-beta.json
@@ -21,7 +21,7 @@
             "    }",
             "}",
             "CreateFile 'config.ini'",
-            "CreateFile 'splog.txt"
+            "CreateFile 'splog.txt'"
         ]
     },
     "uninstaller": {

--- a/bucket/snipaste-beta.json
+++ b/bucket/snipaste-beta.json
@@ -30,7 +30,7 @@
             "    if (Test-Path \"$persist_dir\\$file\") {",
             "        Remove-Item \"$persist_dir\\$file\" -Force",
             "    }",
-            "    Copy-Item \"$dir\\$file\" \"$persist_dir\" -Force",
+            "    Copy-Item \"$dir\\$file\" \"$persist_dir\" -Force -ErrorAction SilentlyContinue",
             "}",
             "BackupFile 'config.ini'",
             "BackupFile 'splog.txt'"


### PR DESCRIPTION
- fix error while unintalling `snipaste-beta`
``` powershell
Uninstalling 'snipaste-beta' (2.7.3-Beta).
Running uninstaller script...
Removing shortcut ~\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Scoop Apps\Snipaste.lnk
Unlinking ~\scoop\apps\snipaste-beta\current
Get-Item : 找不到路径“C:\Users\Akariiin\scoop\apps\snipaste-beta\2.7.3-Beta\config.ini”，因为该路径不存在。
所在位置 C:\Users\Akariiin\scoop\apps\scoop\current\lib\install.ps1:1216 字符: 23
+             $source = Get-Item "$dir\$source"
+                       ~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\Akarii...Beta\config.ini:String) [Get-Item], ItemNotFoundExcep
   tion
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand

'snipaste-beta' was uninstalled.
```
- persist `crashes`  folder
- persist `splog.txt`