### PR TITLE
unityhub: Add `post_install` to resolve login failure

### DIFF
--- a/bucket/unityhub.json
+++ b/bucket/unityhub.json
@@ -17,6 +17,19 @@
             }
         }
     },
+    "post_install": [
+        "Write-Host \"Registering unityhub:// protocol handler\"",
+        "$regpath = \"HKCU:\\SOFTWARE\\Classes\\unityhub\"",
+        "New-Item -Path $regpath -Value \"URL:unityhub\" -Force | Out-Null",
+        "New-ItemProperty -Path $regpath -Name \"URL Protocol\" -PropertyType String -Force | Out-Null",
+        "New-Item -Path \"$regpath\\shell\\Open\\command\" -Value \"`\"$dir\\Unity Hub.exe`\" `\"%1`\"\" -Force| Out-Null"
+    ],
+    "uninstaller": {
+        "script": [
+            "Write-Host \"Unregistering unityhub:// protocol handler\"",
+            "Remove-Item \"HKCU:\\SOFTWARE\\Classes\\unityhub\" -Recurse -Force"
+        ]
+    },
     "shortcuts": [
         [
             "Unity Hub.exe",


### PR DESCRIPTION
When click sign in, the unity hub will open the default browser to login and bring up the unity hub to complete the login.