### PR TITLE
Changed checkver of winlibs-mingw to allow autoupdate to gcc12.

### DIFF
--- a/bucket/winlibs-mingw-llvm-ucrt.json
+++ b/bucket/winlibs-mingw-llvm-ucrt.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://winlibs.com/",
     "description": "winlibs standalone build of GCC compiler and MinGW-w64 with LLVM and UCRT",
-    "version": "11.3.0-14.0.3-10.0.0-ucrt-r3",
+    "version": "12.1.0-14.0.4-10.0.0-ucrt-r2",
     "license": "GPL-2.0-only,BSD-2-Clause,Apache-2.0,ZPL-2.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.3.0-14.0.3-10.0.0-ucrt-r3/winlibs-x86_64-posix-seh-gcc-11.3.0-llvm-14.0.3-mingw-w64ucrt-10.0.0-r3.7z",
-            "hash": "810a6a8361bc1a83bfe68745adbec30998a47b6a3f4d384505cffcc24a5dcd19",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-12.1.0-llvm-14.0.4-mingw-w64ucrt-10.0.0-r2.7z",
+            "hash": "0d9adaa44f9d812e31950b814500f266b6a0e1ef564660f48701da40b7860645",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.3.0-14.0.3-10.0.0-ucrt-r3/winlibs-i686-posix-dwarf-gcc-11.3.0-llvm-14.0.3-mingw-w64ucrt-10.0.0-r3.7z",
-            "hash": "129acf5a5696b751177f68342b0b02a1e906377307461ba894e2c9b8156a8f9a",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.1.0-llvm-14.0.4-mingw-w64ucrt-10.0.0-r2.7z",
+            "hash": "a4078f9e9038a81798ddd895d0a60f715780453c6f84bde8fde8f874204288b4",
             "extract_dir": "mingw32"
         }
     },

--- a/bucket/winlibs-mingw-llvm-ucrt.json
+++ b/bucket/winlibs-mingw-llvm-ucrt.json
@@ -17,7 +17,7 @@
     },
     "env_add_path": "bin",
     "checkver": {
-        "regex": "/download/(?<version>((?<gccVersion>11[\\d.]+)-(?<llvmVersion>[\\d.]+)-(?<mingwVersion>[\\d.]+)-ucrt-(?<revision>[\\w]+)))"
+        "regex": "/download/(?<version>((?<gccVersion>[\\d.]+)-(?<llvmVersion>[\\d.]+)-(?<mingwVersion>[\\d.]+)-ucrt-(?<revision>[\\w]+)))"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/winlibs-mingw-msvcrt.json
+++ b/bucket/winlibs-mingw-msvcrt.json
@@ -17,7 +17,7 @@
     },
     "env_add_path": "bin",
     "checkver": {
-        "regex": "/download/(?<version>((?<gccVersion>11[\\d.]+)(-(?<llvmVersion>[\\d.]+))?-(?<mingwVersion>[\\d.]+)-msvcrt-(?<revision>[\\w]+)))"
+        "regex": "/download/(?<version>((?<gccVersion>[\\d.]+)(-(?<llvmVersion>[\\d.]+))?-(?<mingwVersion>[\\d.]+)-msvcrt-(?<revision>[\\w]+)))"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/winlibs-mingw-msvcrt.json
+++ b/bucket/winlibs-mingw-msvcrt.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://winlibs.com/",
     "description": "winlibs standalone build of GCC compiler and MinGW-w64 with MSVCRT",
-    "version": "11.3.0-14.0.3-10.0.0-msvcrt-r3",
+    "version": "12.1.0-14.0.4-10.0.0-msvcrt-r2",
     "license": "GPL-2.0-only,BSD-2-Clause,Apache-2.0,ZPL-2.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.3.0-14.0.3-10.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-11.3.0-mingw-w64msvcrt-10.0.0-r3.7z",
-            "hash": "fe72d6ef32d5a2b731488406796509aa3df326670709fb9886fb78f72b04f5ae",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-msvcrt-r2/winlibs-x86_64-posix-seh-gcc-12.1.0-mingw-w64msvcrt-10.0.0-r2.7z",
+            "hash": "48b377f73490ed6811f77a063cbcfba04dabe6ae6bd5653a27848ad3ed7ab771",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.3.0-14.0.3-10.0.0-msvcrt-r3/winlibs-i686-posix-dwarf-gcc-11.3.0-mingw-w64msvcrt-10.0.0-r3.7z",
-            "hash": "64e69f4afd68bcd2a94bf4cc0237ae0641d237dd20f1a32f9834fc1b73381e72",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-msvcrt-r2/winlibs-i686-posix-dwarf-gcc-12.1.0-mingw-w64msvcrt-10.0.0-r2.7z",
+            "hash": "1d9419a27fa6f4df29248a1e019ae366f8efe6af50cfe5052f9f411dacda30b5",
             "extract_dir": "mingw32"
         }
     },

--- a/bucket/winlibs-mingw-ucrt.json
+++ b/bucket/winlibs-mingw-ucrt.json
@@ -17,7 +17,7 @@
     },
     "env_add_path": "bin",
     "checkver": {
-        "regex": "/download/(?<version>((?<gccVersion>11[\\d.]+)(-(?<llvmVersion>[\\d.]+))?-(?<mingwVersion>[\\d.]+)-ucrt-(?<revision>[\\w]+)))"
+        "regex": "/download/(?<version>((?<gccVersion>[\\d.]+)(-(?<llvmVersion>[\\d.]+))?-(?<mingwVersion>[\\d.]+)-ucrt-(?<revision>[\\w]+)))"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/winlibs-mingw-ucrt.json
+++ b/bucket/winlibs-mingw-ucrt.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://winlibs.com/",
     "description": "winlibs standalone build of GCC compiler and MinGW-w64 with UCRT",
-    "version": "11.3.0-14.0.3-10.0.0-ucrt-r3",
+    "version": "12.1.0-14.0.4-10.0.0-ucrt-r2",
     "license": "GPL-2.0-only,BSD-2-Clause,Apache-2.0,ZPL-2.1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.3.0-14.0.3-10.0.0-ucrt-r3/winlibs-x86_64-posix-seh-gcc-11.3.0-mingw-w64ucrt-10.0.0-r3.7z",
-            "hash": "7e9f65a754fa5780a1bf0a4c26c42a63320a1f15376ba097b9da5463c9cfef77",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-12.1.0-mingw-w64ucrt-10.0.0-r2.7z",
+            "hash": "702bfba6bc31b1221f66622d6491bcc8a0cf284f80a16f209787a637235e519a",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.3.0-14.0.3-10.0.0-ucrt-r3/winlibs-i686-posix-dwarf-gcc-11.3.0-mingw-w64ucrt-10.0.0-r3.7z",
-            "hash": "9e33fa7b2a7e57e449db88aebae4aaaac5597764e4b10fefbf539aa36d65aa3f",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/12.1.0-14.0.4-10.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-12.1.0-mingw-w64ucrt-10.0.0-r2.7z",
+            "hash": "3291336f86353934e069dbe3924592b84d67dc7e0c002948bc444833a062c72b",
             "extract_dir": "mingw32"
         }
     },


### PR DESCRIPTION
Since winlibs-mingw has update its gcc version to 12.x, original checkver has explicit version 11 in regex, this prevent it to autoupdate to latest version.
I just delete the "11" in regex, I don't get the point why we need it. If actually an explicit gcc version is needed, you may change "11" to "12" to get up to latest release. Appreciate.