### PR TITLE
swift: update to libicu69

### DIFF
--- a/bucket/swift.json
+++ b/bucket/swift.json
@@ -19,7 +19,7 @@
     },
     "env_add_path": [
         "Library\\Developer\\Toolchains\\unknown-Asserts-development.xctoolchain\\usr\\bin",
-        "Library\\icu-67\\usr\\bin",
+        "Library\\icu-69.1\\usr\\bin",
         "Library\\Swift-development\\bin"
     ],
     "env_set": {


### PR DESCRIPTION
Swift moved to `libicu69` in the latest versions, so `env_add_path` needed an update.