### PR TITLE
dandanplay: Update to version 12.5.0

### DIFF
--- a/bucket/dandanplay.json
+++ b/bucket/dandanplay.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://www.dandanplay.com/",
     "description": "A free to use bangumi player with danmaku support",
-    "version": "12.4.0",
+    "version": "12.5.0",
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://dandan.sakurateam.top/dandanplay-x64_12.4.0.zip",
-            "hash": "002d7cb263ba09b74040d7d9da681cdccd3165e2acaad6ed7091b5e40b3bffec",
+            "url": "https://dandan.sakurateam.top/dandanplay-x64_12.5.0.zip",
+            "hash": "264f7c879bbf7d132b721d05134ae0d8407f6a8655efbbbaecf4740ac443d2af",
             "extract_dir": "dandanplay-x64"
         }
     },


### PR DESCRIPTION
Today Dandanplay released version 12.5.0, it updated the server address, version 12.4.0 is no longer available. Please update to the latest version as soon as possible.