### PR TITLE
crystaldisk* apps | clash for windows(-np): add arm64 architecture

### DIFF
--- a/bucket/clash-for-windows-np.json
+++ b/bucket/clash-for-windows-np.json
@@ -7,22 +7,26 @@
         "64bit": {
             "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.5/Clash.for.Windows.Setup.0.20.5.exe#/dl.7z",
             "hash": "ce9ed981e3c867f0f708a621ff64687d29a1f84c8bec2dc018e6ae14d133bb18",
-            "installer": {
-                "script": [
-                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
-                ]
-            }
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
+            ]
         },
         "32bit": {
             "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.5/Clash.for.Windows.Setup.0.20.5.ia32.exe#/dl.7z",
             "hash": "6496e7047257cdde899fde63103ee5ae8d1725dae406512a7939029ee5234822",
-            "installer": {
-                "script": [
-                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
-                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
-                ]
-            }
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
+            ]
+        },
+        "arm64": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.5/Clash.for.Windows.Setup.0.20.5.arm64.exe#/dl.7z",
+            "hash": "cd99aaf1fdbf5079c6c13c503b4cc7001d2101e1570a9d79ccc27ae2ee90eefd",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
+            ]
         }
     },
     "shortcuts": [
@@ -48,6 +52,14 @@
                     "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
                     "mode": "extract",
                     "regex": "(?m)^ia32-exe: $sha256"
+                }
+            },
+            "arm64": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.arm64.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "(?m)^arm64-exe: $sha256"
                 }
             }
         }

--- a/bucket/clash-for-windows.json
+++ b/bucket/clash-for-windows.json
@@ -19,6 +19,14 @@
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
                 "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
             ]
+        },
+        "arm64": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.20.5/Clash.for.Windows.Setup.0.20.5.arm64.exe#/dl.7z",
+            "hash": "cd99aaf1fdbf5079c6c13c503b4cc7001d2101e1570a9d79ccc27ae2ee90eefd",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-arm64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse"
+            ]
         }
     },
     "installer": {
@@ -65,6 +73,14 @@
                     "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
                     "mode": "extract",
                     "regex": "(?m)^ia32-exe: $sha256"
+                }
+            },
+            "arm64": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows.Setup.$version.arm64.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/sha256sum",
+                    "mode": "extract",
+                    "regex": "(?m)^arm64-exe: $sha256"
                 }
             }
         }

--- a/bucket/crystaldiskinfo-shizuku-edition.json
+++ b/bucket/crystaldiskinfo-shizuku-edition.json
@@ -42,7 +42,7 @@
     ],
     "checkver": {
         "url": "https://osdn.net/projects/crystaldiskinfo/",
-        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskInfo ([\\d.]+)<"
+        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskInfo ([\\w.]+)<"
     },
     "autoupdate": {
         "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskinfo/$matchRelease/CrystalDiskInfo$underscoreVersionShizuku.zip",

--- a/bucket/crystaldiskinfo-shizuku-edition.json
+++ b/bucket/crystaldiskinfo-shizuku-edition.json
@@ -11,10 +11,6 @@
                 [
                     "DiskInfo64S.exe",
                     "CrystalDiskInfo Shizuku Edition"
-                ],
-                [
-                    "DiskInfoA64S.exe",
-                    "CrystalDiskInfo Shizuku Edition (ARM)"
                 ]
             ]
         },
@@ -23,17 +19,21 @@
                 [
                     "DiskInfo32S.exe",
                     "CrystalDiskInfo Shizuku Edition"
-                ],
+                ]
+            ]
+        },
+        "arm64": {
+            "shortcuts": [
                 [
-                    "DiskInfoA32S.exe",
-                    "CrystalDiskInfo Shizuku Edition (ARM)"
+                    "DiskInfoA64S.exe",
+                    "CrystalDiskInfo Shizuku Edition"
                 ]
             ]
         }
     },
     "pre_install": [
-        "if(!(Test-Path \"$persist_dir\\DiskInfo.ini\")) {",
-        "Add-Content \"$dir\\DiskInfo.ini\" $null",
+        "if (!(Test-Path \"$persist_dir\\DiskInfo.ini\")) {",
+        "    New-Item \"$dir\\DiskInfo.ini\" -ItemType File | Out-Null",
         "}"
     ],
     "persist": [
@@ -50,6 +50,5 @@
             "url": "https://osdn.net/projects/crystaldiskinfo/releases/rss",
             "xpath": "//osdn:file[@url='https://osdn.net/projects/crystaldiskinfo/downloads/$matchRelease/CrystalDiskInfo$underscoreVersionShizuku.zip/']/@sha256"
         }
-    },
-    "notes": "If you are using ARM SoC, run 'CrystalDiskInfo Shizuku Edition (ARM)' instead."
+    }
 }

--- a/bucket/crystaldiskinfo-shizuku-edition.json
+++ b/bucket/crystaldiskinfo-shizuku-edition.json
@@ -42,7 +42,7 @@
     ],
     "checkver": {
         "url": "https://osdn.net/projects/crystaldiskinfo/",
-        "regex": "<a href=\"/projects/crystaldiskinfo/releases/(?<release>[\\d]*)\">CrystalDiskInfo ([\\d+\\.*]+)</a>"
+        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskInfo ([\\d.]+)<"
     },
     "autoupdate": {
         "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskinfo/$matchRelease/CrystalDiskInfo$underscoreVersionShizuku.zip",

--- a/bucket/crystaldiskinfo-shizuku-edition.json
+++ b/bucket/crystaldiskinfo-shizuku-edition.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://crystalmark.info/en/",
     "description": "CrystalDiskInfo is a HDD/SSD utility software which supports S.M.A.R.T and a part of USB-HDD.",
-    "version": "8.17.7",
+    "version": "8.17.8",
     "license": "MIT",
-    "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskinfo/77771/CrystalDiskInfo8_17_7Shizuku.zip",
-    "hash": "4b2bf845dc6ef837a6f355b437625956ac27dc5beaec35f81f22336596368822",
+    "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskinfo/77877/CrystalDiskInfo8_17_8Shizuku.zip",
+    "hash": "7e35eef7936e55f923911e5c5c8eaaef44004699c76f654daa2beadaa0d56ca4",
     "architecture": {
         "64bit": {
             "shortcuts": [
@@ -42,7 +42,7 @@
     ],
     "checkver": {
         "url": "https://osdn.net/projects/crystaldiskinfo/",
-        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskInfo ([\\w.]+)<"
+        "regex": "releases\\/(?<release>[\\d]+)\">CrystalDiskInfo ([\\w.]+)<"
     },
     "autoupdate": {
         "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskinfo/$matchRelease/CrystalDiskInfo$underscoreVersionShizuku.zip",

--- a/bucket/crystaldiskmark-shizuku-edition.json
+++ b/bucket/crystaldiskmark-shizuku-edition.json
@@ -45,7 +45,7 @@
     ],
     "checkver": {
         "url": "https://osdn.net/projects/crystaldiskmark/",
-        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskMark ([\\w.]+)<"
+        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskMark ([\\d.]+)<"
     },
     "autoupdate": {
         "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskmark/$matchRelease/CrystalDiskMark$underscoreVersionShizuku.zip",

--- a/bucket/crystaldiskmark-shizuku-edition.json
+++ b/bucket/crystaldiskmark-shizuku-edition.json
@@ -2,7 +2,7 @@
     "homepage": "https://crystalmark.info/en/",
     "description": "CrystalDiskMark is a disk benchmark software.",
     "version": "8.0.4b",
-    "license": "BSD-3-Clause",
+    "license": "MIT",
     "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskmark/77539/CrystalDiskMark8_0_4bShizuku.zip",
     "hash": "ee15f4782258e8d64a050859d22fe72077e671bccda4608cb2953a1b44a47bd6",
     "architecture": {
@@ -45,7 +45,7 @@
     ],
     "checkver": {
         "url": "https://osdn.net/projects/crystaldiskmark/",
-        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskMark ([\\w.]+)<"
+        "regex": "releases\\/(?<release>[\\d]+)\">CrystalDiskMark ([\\w.]+)<"
     },
     "autoupdate": {
         "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskmark/$matchRelease/CrystalDiskMark$underscoreVersionShizuku.zip",

--- a/bucket/crystaldiskmark-shizuku-edition.json
+++ b/bucket/crystaldiskmark-shizuku-edition.json
@@ -45,7 +45,7 @@
     ],
     "checkver": {
         "url": "https://osdn.net/projects/crystaldiskmark/",
-        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskMark ([\\d.]+)<"
+        "regex": "releases/(?<release>[\\d]+)\">CrystalDiskMark ([\\w.]+)<"
     },
     "autoupdate": {
         "url": "https://dotsrc.dl.osdn.net/osdn/crystaldiskmark/$matchRelease/CrystalDiskMark$underscoreVersionShizuku.zip",

--- a/bucket/crystaldiskmark-shizuku-edition.json
+++ b/bucket/crystaldiskmark-shizuku-edition.json
@@ -11,10 +11,6 @@
                 [
                     "DiskMark64S.exe",
                     "CrystalDiskMark Shizuku Edition"
-                ],
-                [
-                    "DiskMarkA64S.exe",
-                    "CrystalDiskMark Shizuku Edition (ARM)"
                 ]
             ]
         },
@@ -23,25 +19,29 @@
                 [
                     "DiskMark32S.exe",
                     "CrystalDiskMark Shizuku Edition"
-                ],
+                ]
+            ]
+        },
+        "arm64": {
+            "shortcuts": [
                 [
-                    "DiskMarkA32S.exe",
-                    "CrystalDiskMark Shizuku Edition (ARM)"
+                    "DiskMarkA64S.exe",
+                    "CrystalDiskMark Shizuku Edition"
                 ]
             ]
         }
     },
     "persist": [
         "DiskMark32S.ini",
-        "DiskMarkA32S.ini",
         "DiskMark64S.ini",
         "DiskMarkA64S.ini"
     ],
     "pre_install": [
-        "if(!(Test-Path \"$persist_dir\\DiskMark64S.ini\")) { Add-Content \"$dir\\DiskMark64S.ini\" $null }",
-        "if(!(Test-Path \"$persist_dir\\DiskMarkA64S.ini\")) { Add-Content \"$dir\\DiskMarkA64S.ini\" $null }",
-        "if(!(Test-Path \"$persist_dir\\DiskMark32S.ini\")) { Add-Content \"$dir\\DiskMark32S.ini\" $null }",
-        "if(!(Test-Path \"$persist_dir\\DiskMarkA32S.ini\")) { Add-Content \"$dir\\DiskMarkA32S.ini\" $null }"
+        "'DiskMark32S.ini', 'DiskMark64S.ini', 'DiskMarkA64S.ini' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) {",
+        "        New-Item \"$dir\\$_\" -ItemType File | Out-Null",
+        "    }",
+        "}"
     ],
     "checkver": {
         "url": "https://osdn.net/projects/crystaldiskmark/",
@@ -53,6 +53,5 @@
             "url": "https://osdn.net/projects/crystaldiskmark/releases/rss",
             "xpath": "//osdn:file[@url='https://osdn.net/projects/crystaldiskmark/downloads/$matchRelease/CrystalDiskMark$underscoreVersionShizuku.zip/']/@sha256"
         }
-    },
-    "notes": "If you are using ARM SoC, run 'CrystalDiskMark Shizuku Edition (ARM)' instead."
+    }
 }


### PR DESCRIPTION
For `clash-for-windows`:
- Add support for arm64

For `clash-for-windows-np`:
- Add support for arm64

For `crystaldiskinfo-shizuku-edition`:
- Add support for arm64

For `crystaldiskmark-shizuku-edition`:
- Add support for arm64
- Drop support for arm32