### PR TITLE
Add micromamba default prefix dir to the path

### DIFF
--- a/bucket/micromamba.json
+++ b/bucket/micromamba.json
@@ -20,7 +20,11 @@
     "env_set": {
         "MAMBA_ROOT_PREFIX": "$dir\\mamba"
     },
-    "env_add_path": "mamba",
+    "env_add_path": {
+        "mamba",
+        "mamba\\Scripts",
+        "mamba\\Scripts\\Library\\bin"
+    },
     "post_install": "Remove-Item \"$dir\\Library\" -Force",
     "persist": "mamba",
     "checkver": {

--- a/bucket/micromamba.json
+++ b/bucket/micromamba.json
@@ -20,6 +20,7 @@
     "env_set": {
         "MAMBA_ROOT_PREFIX": "$dir\\mamba"
     },
+    "env_add_path": "mamba",
     "post_install": "Remove-Item \"$dir\\Library\" -Force",
     "persist": "mamba",
     "checkver": {


### PR DESCRIPTION
This change allows the default prefix dir to be added to the path environment, allows using python without activating the base environment. The behavior of micromamba in the sense of "installing python with some package manager" would more like conda, make it easier to use