### PR TITLE
besttrace: Add new shortcut

### DIFF
--- a/bucket/besttrace.json
+++ b/bucket/besttrace.json
@@ -10,6 +10,11 @@
         [
             "17monipdb.exe",
             "Best Trace"
+        ],
+        [
+            "17monipdb.exe",
+            "Best Trace 路由跟踪",
+            "tracert"
         ]
     ]
 }


### PR DESCRIPTION
Add a shortcut that will be created in the official installer.
This new shortcut will open the route tracking page directly.
Local test passed.