### PR TITLE
fix(texlive-full): Update texlive-full.json path from win32 to windows

### DIFF
--- a/bucket/texlive-full.json
+++ b/bucket/texlive-full.json
@@ -33,7 +33,7 @@
     },
     "env_add_path": [
         "bin\\win64",
-        "bin\\win32"
+        "bin\\windows"
     ],
     "shortcuts": [
         [
@@ -41,7 +41,7 @@
             "Tex Live Manager"
         ],
         [
-            "bin\\win32\\texworks.exe",
+            "bin\\windows\\texworks.exe",
             "TeXworks"
         ]
     ],


### PR DESCRIPTION
2023 的 texlive-full 中的 路径有一些变更