### PR TITLE
downkyi: fix download url error

### DIFF
--- a/bucket/downkyi.json
+++ b/bucket/downkyi.json
@@ -3,8 +3,8 @@
     "description": "BiliBili Vedio Downloader",
     "homepage": "https://github.com/leiurayer/downkyi",
     "license": "Apache-2.0",
-    "url": "https://github.com/leiurayer/downkyi/releases/download/v1.5.8/DownKyi-1.5.8.zip",
-    "hash": "f0a1cacd9a1815c90de20682a950fe9b04505500259c8cbf931af0ddf42910a9",
+    "url": "https://github.com/leiurayer/downkyi/releases/download/v1.5.8/DownKyi-1.5.8-fix1.zip",
+    "hash": "6417f4d44f453c5b4f5d7ada38b974492886b983ce63bb30458f5a2ab014de8a",
     "shortcuts": [
         [
             "DownKyi.exe",


### PR DESCRIPTION
[v1.5.8 release page](https://github.com/leiurayer/downkyi/releases/tag/v1.5.8)