### PR TITLE
upload reicon.json

### DIFF
--- a/bucket/reicon.json
+++ b/bucket/reicon.json
@@ -4,7 +4,7 @@
     "homepage": "https://www.sordum.org/8366/reicon-v1-9-restore-desktop-icon-layouts/",
     "license": "Freeware",
     "url": "https://www.sordum.org/files/restore-desktop-icon-layouts/ReIcon.zip",
-    "hash": "af2e08378d538229b18ec33c7124b98f16bbb382f372c5abf9ea6fdba5cfb1b4",
+    "hash": "10D000E05B59022656900672041E0B92FF61B506F457D857FB0516E6E06791B3",
     "extract_dir": "ReIcon",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
fix the `hash` to hash-256 of ReIcon.zip.
archive from https://www.sordum.org/8366/reicon-v2-0-restore-desktop-icon-layouts.