### PR TITLE
dandanplay: Fix error when running installer script

### DIFF
--- a/bucket/dandanplay.json
+++ b/bucket/dandanplay.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://www.dandanplay.com/",
     "description": "A free to use bangumi player with danmaku support",
-    "version": "14.5.1",
+    "version": "14.5.2",
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://dandan.sakurateam.top/dandanplay-x64_14.5.1.exe",
-            "hash": "bfa9c640a3775cb37a2a52159725eca814faf6a85f8c35b2938ecca5d894054d"
+            "url": "https://dandan.sakurateam.top/dandanplay-x64_14.5.2.exe",
+            "hash": "06f3766eedece754de18c63fc26ff5a7f1969345160bfb3434c9e5b2b8fd51cb"
         }
     },
     "pre_install": [

--- a/bucket/dandanplay.json
+++ b/bucket/dandanplay.json
@@ -25,7 +25,7 @@
     "installer": {
         "script": [
             "Start-Process \"$dir\\$fname\" \"/extract $dir\" -PassThru -NoNewWindow | Wait-Process",
-            "$subdir = (Get-ChildItem -Path \"$dir\" -Exclude \"*NET*\" -Directory).Name",
+            "$subdir = (Get-ChildItem -Path \"$dir\" -Exclude \"*NET*\",\"WebView2\" -Directory).Name",
             "movedir \"$dir\\$subdir\" \"$dir\" | Out-Null",
             "Remove-Item \"$dir\\$fname\",\"$dir\\decoder.dll\",\"$dir\\$subdir\" -Force -ErrorAction SilentlyContinue"
         ]


### PR DESCRIPTION
In latest version, one more folder named `WebView2` would be extracted from installer, and cause following error:
```powershell
Running installer script...
Could not find 'BDC5719 WebView2'! (error 16)
At C:\Users\A1\scoop\apps\scoop\current\lib\core.ps1:638 char:9
+         throw "Could not find '$(fname $from)'! (error $($proc.ExitCo ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Could not find ...w2'! (error 16):String) [], RuntimeException
    + FullyQualifiedErrorId : Could not find 'BDC5719 WebView2'! (error 16)
```

Exclude this folder in `Get-ChildItem` would fix the error. 