### PR TITLE
update to version 2.6.0

### DIFF
--- a/bucket/lxmusic.json
+++ b/bucket/lxmusic.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.5.0",
+    "version": "2.6.0",
     "homepage": "http://lyswhut.github.io/lx-music-doc/",
     "description": "a free & open source music finder",
     "license": "Apache-2.0",
@@ -14,12 +14,12 @@
     },
     "architecture": {
         "32bit": {
-            "url": "https://github.com/lyswhut/lx-music-desktop/releases/download/v2.5.0/lx-music-desktop-v2.5.0-win7_x86-green.7z",
-            "hash": "md5:8bf9904ce565e9ea34409f15bb47bbcd"
+            "url": "https://github.com/lyswhut/lx-music-desktop/releases/download/v2.6.0/lx-music-desktop-v2.6.0-win7_x86-green.7z",
+            "hash": "md5:3847e87d229106a88b04d3bdd0f92f0e"
         },
         "64bit": {
-            "url": "https://github.com/lyswhut/lx-music-desktop/releases/download/v2.5.0/lx-music-desktop-v2.5.0-win_x64-green.7z",
-            "hash": "md5:5600f7e6d3c2579cf9b5574501deefe3"
+            "url": "https://github.com/lyswhut/lx-music-desktop/releases/download/v2.6.0/lx-music-desktop-v2.6.0-win_x64-green.7z",
+            "hash": "md5:adb9682ff562fcd8438192f366091678"
         },
         "arm64": {
             "url": "https://github.com/lyswhut/lx-music-desktop/releases/download/v2.5.0/lx-music-desktop-v2.5.0-win_arm64-green.7z",


### PR DESCRIPTION
There is no Windows ARM version of the software in the official release version 2.6.0.