### PR TITLE
imewlconverter: Fix extract_dir

### DIFF
--- a/bucket/imewlconverter.json
+++ b/bucket/imewlconverter.json
@@ -5,6 +5,7 @@
     "license": "GPL-3.0-only",
     "url": "https://github.com/studyzy/imewlconverter/releases/download/v3.1.0/imewlconverter_Windows.zip",
     "hash": "b3daa390cf7e4712545ef74dcbacdfc4a0c198c16b8c36ea8ff39dc5ac1426b2",
+    "extract_dir": "publish",
     "shortcuts": [
         [
             "深蓝词库转换.exe",


### PR DESCRIPTION
The previous manifest incorrectly attempted to link a shortcut that did not exist in the expected directory. This change updates the 'extract_dir' to ensure that the contents of the 'publish' directory within the zip file are correctly extracted to the 'imewlconverter' directory, allowing for the shortcut to be properly created.