### PR TITLE
msys2-cn@20241208: fix cannot be recognized by ridk

### DIFF
--- a/bucket/msys2-cn.json
+++ b/bucket/msys2-cn.json
@@ -66,6 +66,9 @@
             "Remove-Module -Name DoradoUtils"
         ]
     },
+    "env_set": {
+        "MSYS2_PATH": "$dir"
+    },
     "bin": [
         [
             "msys2_shell.cmd",


### PR DESCRIPTION
The Ruby Installerrelies on the `scoop prefix msys2` command to ascertain whether MSYS2 has been installed via Scoop. This detection method, however, fails to recognize the variant named `msys2-cn` in this bucket, leading to unsuccessful detection. Consequently, despite MSYS2 being installed, the installer cannot locate it and erroneously concludes that "MSYS2 seems to be unavailable."

https://github.com/oneclick/rubyinstaller2/blob/ff06a60e42f98807b2d1329d6774cf6c72074157/lib/ruby_installer/build/msys2_installation.rb#L48-L104

The modification is to add an environment variable so that the installer can recognize msys2-cn in `MSYS2_PATH`.
