### PR TITLE
utools: Update to version 6.1.0 (close #934)

### DIFF
--- a/bucket/utools.json
+++ b/bucket/utools.json
@@ -2,18 +2,18 @@
     "homepage": "https://u.tools/",
     "description": "Your productive tools set and launcher.",
     "license": "Proprietary",
-    "version": "5.1.0",
+    "version": "6.1.0",
     "architecture": {
         "64bit": {
-            "url": "https://res.u-tools.cn/version2/uTools-5.1.0.exe#/dl.7z",
-            "hash": "sha512:d796d93f66cb5aeedcfdf0e6fbbe5272e4adde4852aa03c13a3debaf99c603ff6366129ededc05c13db932cf5d8a126a64bb49838dab7ecc12d4b2477dd6eb41",
+            "url": "https://open.u-tools.cn/download/uTools-6.1.0.exe#/dl.7z",
+            "hash": "b6eea8420f124dda26823c846f846f04bd2ceb6693303a7d7d273d43ceabd892",
             "installer": {
                 "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR/app-64.7z\" \"$dir\""
             }
         },
         "32bit": {
-            "url": "https://res.u-tools.cn/version2/uTools-5.1.0-ia32.exe#/dl.7z",
-            "hash": "sha512:15f692c4578284c0ff88640a90d83ea4ed75e9d20bc8d12fde45712f5a4dcd2cc13c5b75201fbd46c896d36f09d2218e5e8d6dd2b2ebec4c389be7bb10aee0d0",
+            "url": "https://open.u-tools.cn/download/uTools-6.1.0-ia32.exe#/dl.7z",
+            "hash": "1cd987fdbabb7b64f13d416cd5ae5918cad1d9c5e5882d53b49d84467c5d2b7d",
             "installer": {
                 "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR/app-32.7z\" \"$dir\""
             }
@@ -27,26 +27,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://res.u-tools.cn/version2/latest.yml",
-        "regex": "version: ([\\d.]+)"
+        "url": "https://www.u-tools.cn/download/",
+        "regex": "/download/uTools-([\\d.]+).exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://res.u-tools.cn/version2/uTools-$version.exe#/dl.7z",
-                "hash": {
-                    "url": "https://res.u-tools.cn/version2/latest.yml?",
-                    "mode": "extract",
-                    "regex": "(?sm)$version.exe.*?sha512: $base64"
-                }
+                "url": "https://open.u-tools.cn/download/uTools-$version.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://res.u-tools.cn/version2/uTools-$version-ia32.exe#/dl.7z",
-                "hash": {
-                    "url": "https://res.u-tools.cn/version2/latest-ia32.yml?",
-                    "mode": "extract",
-                    "regex": "(?sm)$version-ia32.exe.*?sha512: $base64"
-                }
+                "url": "https://open.u-tools.cn/download/uTools-$version-ia32.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
checkver logs:

```powershell
utools: 6.1.0 (scoop version is 5.1.0) autoupdate available
Autoupdating utools
DEBUG[1737735949] [$updatedProperties] = [url hash] -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:478:5
DEBUG[1737735949] $substitutions (hashtable) -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:216:5      
DEBUG[1737735949] $substitutions.$basename                      uTools-6.1.0-ia32.exe
DEBUG[1737735949] $substitutions.$version                       6.1.0
DEBUG[1737735949] $substitutions.$matchHead                     6.1.0
DEBUG[1737735949] $substitutions.$dashVersion                   6-1-0
DEBUG[1737735949] $substitutions.$dotVersion                    6.1.0
DEBUG[1737735949] $substitutions.$baseurl                       https://open.u-tools.cn/download
DEBUG[1737735949] $substitutions.$matchTail
DEBUG[1737735949] $substitutions.$underscoreVersion             6_1_0
DEBUG[1737735949] $substitutions.$buildVersion
DEBUG[1737735949] $substitutions.$preReleaseVersion             6.1.0
DEBUG[1737735949] $substitutions.$match1                        6.1.0
DEBUG[1737735949] $substitutions.$majorVersion                  6
DEBUG[1737735949] $substitutions.$patchVersion                  0
DEBUG[1737735949] $substitutions.$cleanVersion                  610
DEBUG[1737735949] $substitutions.$minorVersion                  1
DEBUG[1737735949] $substitutions.$urlNoExt                      https://open.u-tools.cn/download/uTools-6.1.0-ia32      
DEBUG[1737735949] $substitutions.$url                           https://open.u-tools.cn/download/uTools-6.1.0-ia32.exe  
DEBUG[1737735949] $substitutions.$basenameNoExt                 uTools-6.1.0-ia32
DEBUG[1737735949] $hashfile_url = $null -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:219:5
Downloading uTools-6.1.0-ia32.exe to compute hashes!
INFO  [UrlProxy] You are in CN.
uTools-6.1.0-ia32.exe (62.7 MB) [=============================================================================] 100%
Computed hash: 1cd987fdbabb7b64f13d416cd5ae5918cad1d9c5e5882d53b49d84467c5d2b7d
DEBUG[1737735952] $substitutions (hashtable) -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:216:5      
DEBUG[1737735952] $substitutions.$basename                      uTools-6.1.0.exe
DEBUG[1737735952] $substitutions.$version                       6.1.0
DEBUG[1737735952] $substitutions.$matchHead                     6.1.0
DEBUG[1737735952] $substitutions.$dashVersion                   6-1-0
DEBUG[1737735952] $substitutions.$dotVersion                    6.1.0
DEBUG[1737735952] $substitutions.$baseurl                       https://open.u-tools.cn/download
DEBUG[1737735952] $substitutions.$matchTail
DEBUG[1737735952] $substitutions.$underscoreVersion             6_1_0
DEBUG[1737735952] $substitutions.$buildVersion
DEBUG[1737735952] $substitutions.$preReleaseVersion             6.1.0
DEBUG[1737735952] $substitutions.$match1                        6.1.0
DEBUG[1737735952] $substitutions.$majorVersion                  6
DEBUG[1737735952] $substitutions.$patchVersion                  0
DEBUG[1737735952] $substitutions.$cleanVersion                  610
DEBUG[1737735952] $substitutions.$minorVersion                  1
DEBUG[1737735952] $substitutions.$urlNoExt                      https://open.u-tools.cn/download/uTools-6.1.0
DEBUG[1737735952] $substitutions.$url                           https://open.u-tools.cn/download/uTools-6.1.0.exe       
DEBUG[1737735952] $substitutions.$basenameNoExt                 uTools-6.1.0
DEBUG[1737735952] $hashfile_url = $null -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:219:5
Downloading uTools-6.1.0.exe to compute hashes!
INFO  [UrlProxy] You are in CN.
uTools-6.1.0.exe (66.5 MB) [==================================================================================] 100%
Computed hash: b6eea8420f124dda26823c846f846f04bd2ceb6693303a7d7d273d43ceabd892
Writing updated utools manifest
```