### PR TITLE
neteasemusic: Update to version 3.1.3.203419

### DIFF
--- a/bucket/neteasemusic.json
+++ b/bucket/neteasemusic.json
@@ -1,19 +1,19 @@
 {
     "homepage": "https://music.163.com/",
     "description": "The official NetEase Cloud Music client.",
-    "version": "3.1.1.203306",
+    "version": "3.1.3.203419",
     "license": {
         "identifier": "EULA",
         "url": "https://music.163.com/html/web2/service.html"
     },
     "architecture": {
         "64bit": {
-            "url": "https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.1.203306_64.exe#/dl.7z",
-            "hash": "e73e5cc8bca8742c445b39edbe099d44d64489390ca780fffa27c02493ada104"
+            "url": "https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.3.203419_64.exe#/dl.7z",
+            "hash": "afcd6b7b57fc1d9a43f9a23046782b99f0da987495da4d0fade286b7ba812114"
         },
         "32bit": {
-            "url": "https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.1.203306_32.exe#/dl.7z",
-            "hash": "844b3043390102fff8e0b4f892b34d3db0012f268e9354f8c4736e4de759252c"
+            "url": "https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.3.203419_32.exe#/dl.7z",
+            "hash": "09c1b0a21e275a0e5da59f0896303efaac61d50697f6050c48d685d071d48a4a"
         }
     },
     "installer": {
@@ -40,8 +40,9 @@
         ]
     ],
     "checkver": {
-        "url": "https://music.163.com/api/appcustomconfig/get?key=web-pc-beta-download-links",
-        "regex": "(?<version>[\\d.]+)_32.exe"
+        "url": "https://music.163.com/api/appcustomconfig/get",
+        "jsonpath": "$.data.web-new-download.pc64.downloadUrl",
+        "regex": "NeteaseCloudMusic_Music_official_([\\d.]+)_64.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
checkver logs:

```powershell
neteasemusic: 3.1.3.203419 (scoop version is 3.1.1.203306) autoupdate available
Autoupdating neteasemusic
DEBUG[1737737900] [$updatedProperties] = [url hash] -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:478:5
DEBUG[1737737900] $substitutions (hashtable) -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:216:5
DEBUG[1737737900] $substitutions.$dotVersion                    3.1.3.203419
DEBUG[1737737900] $substitutions.$matchTail                     .203419
DEBUG[1737737900] $substitutions.$basenameNoExt                 NeteaseCloudMusic_Music_official_3.1.3.203419_32
DEBUG[1737737900] $substitutions.$patchVersion                  3
DEBUG[1737737900] $substitutions.$match1                        3.1.3.203419
DEBUG[1737737900] $substitutions.$urlNoExt                      https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.3.203419_32
DEBUG[1737737900] $substitutions.$minorVersion                  1
DEBUG[1737737900] $substitutions.$preReleaseVersion             3.1.3.203419
DEBUG[1737737900] $substitutions.$baseurl                       https://d1.music.126.net/dmusic
DEBUG[1737737900] $substitutions.$majorVersion                  3
DEBUG[1737737900] $substitutions.$cleanVersion                  313203419
DEBUG[1737737900] $substitutions.$buildVersion                  203419
DEBUG[1737737900] $substitutions.$dashVersion                   3-1-3-203419
DEBUG[1737737900] $substitutions.$version                       3.1.3.203419
DEBUG[1737737900] $substitutions.$matchHead                     3.1.3
DEBUG[1737737900] $substitutions.$url                           https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.3.203419_32.exe
DEBUG[1737737900] $substitutions.$basename                      NeteaseCloudMusic_Music_official_3.1.3.203419_32.exe     
DEBUG[1737737900] $substitutions.$underscoreVersion             3_1_3_203419
DEBUG[1737737900] $hashfile_url = $null -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:219:5
Downloading NeteaseCloudMusic_Music_official_3.1.3.203419_32.exe to compute hashes!
NeteaseCloudMusic_Music_official_3.1.3.203419_32.exe (131.8 MB) [==============================================] 100%
Computed hash: 09c1b0a21e275a0e5da59f0896303efaac61d50697f6050c48d685d071d48a4a
DEBUG[1737737906] $substitutions (hashtable) -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:216:5       
DEBUG[1737737906] $substitutions.$dotVersion                    3.1.3.203419
DEBUG[1737737906] $substitutions.$matchTail                     .203419
DEBUG[1737737906] $substitutions.$basenameNoExt                 NeteaseCloudMusic_Music_official_3.1.3.203419_64
DEBUG[1737737906] $substitutions.$patchVersion                  3
DEBUG[1737737906] $substitutions.$match1                        3.1.3.203419
DEBUG[1737737906] $substitutions.$urlNoExt                      https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.3.203419_64
DEBUG[1737737906] $substitutions.$minorVersion                  1
DEBUG[1737737906] $substitutions.$preReleaseVersion             3.1.3.203419
DEBUG[1737737906] $substitutions.$baseurl                       https://d1.music.126.net/dmusic
DEBUG[1737737906] $substitutions.$majorVersion                  3
DEBUG[1737737906] $substitutions.$cleanVersion                  313203419
DEBUG[1737737906] $substitutions.$buildVersion                  203419
DEBUG[1737737906] $substitutions.$dashVersion                   3-1-3-203419
DEBUG[1737737906] $substitutions.$version                       3.1.3.203419
DEBUG[1737737906] $substitutions.$matchHead                     3.1.3
DEBUG[1737737906] $substitutions.$url                           https://d1.music.126.net/dmusic/NeteaseCloudMusic_Music_official_3.1.3.203419_64.exe
DEBUG[1737737906] $substitutions.$basename                      NeteaseCloudMusic_Music_official_3.1.3.203419_64.exe     
DEBUG[1737737906] $substitutions.$underscoreVersion             3_1_3_203419
DEBUG[1737737906] $hashfile_url = $null -> ~\scoop\apps\scoop\current\lib\autoupdate.ps1:219:5
Downloading NeteaseCloudMusic_Music_official_3.1.3.203419_64.exe to compute hashes!
NeteaseCloudMusic_Music_official_3.1.3.203419_64.exe (144.0 MB) [==============================================] 100%
Computed hash: afcd6b7b57fc1d9a43f9a23046782b99f0da987495da4d0fade286b7ba812114
Writing updated neteasemusic manifest
```