### PR TITLE
moonlight: Update to version 6.1.0

### DIFF
--- a/bucket/moonlight.json
+++ b/bucket/moonlight.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://github.com/moonlight-stream/moonlight-qt",
     "description": "GameStream client for PCs (Windows, Mac, Linux, and Steam Link)",
-    "version": "6.0.1",
+    "version": "6.1.0",
     "license": "GPL-3.0-only",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/moonlight-stream/moonlight-qt/releases/download/v6.0.1/MoonlightPortable-x86-6.0.1.zip",
-            "hash": "9274e8a8d71cffd53fb07ec3947dde5bae5ae9ecc00cb48ff07f42c9b41370d6"
+        "arm64": {
+            "url": "https://github.com/moonlight-stream/moonlight-qt/releases/download/v6.1.0/MoonlightPortable-arm64-6.1.0.zip",
+            "hash": "c4553d7d7ffde2dd7fcd89be1776afdfd4b1736eaf7db9432b8f3b6a9a2078c6"
         },
         "64bit": {
-            "url": "https://github.com/moonlight-stream/moonlight-qt/releases/download/v6.0.1/MoonlightPortable-x64-6.0.1.zip",
-            "hash": "cb245662e9ba400bf31fbe88f21ec6264c811d0fc75af2ec921e81aa0051ab95"
+            "url": "https://github.com/moonlight-stream/moonlight-qt/releases/download/v6.1.0/MoonlightPortable-x64-6.1.0.zip",
+            "hash": "95f4d0853a31c7fced4b6d233ddf55ee41720963f2e2620a9cb49a21d112aed1"
         }
     },
     "persist": "Moonlight Game Streaming Project",
@@ -23,8 +23,8 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/moonlight-stream/moonlight-qt/releases/download/v$version/MoonlightPortable-x86-$version.zip"
+            "arm64": {
+                "url": "https://github.com/moonlight-stream/moonlight-qt/releases/download/v$version/MoonlightPortable-arm64-$version.zip"
             },
             "64bit": {
                 "url": "https://github.com/moonlight-stream/moonlight-qt/releases/download/v$version/MoonlightPortable-x64-$version.zip"


### PR DESCRIPTION
Moonlight canceled the 32-bit version, causing the autoupdate to fail.

BTW, [extras/moonlight](https://github.com/ScoopInstaller/Extras/blob/master/bucket/moonlight.json) already exists.