### PR TITLE
wix: Update extract path

### DIFF
--- a/bucket/wix.json
+++ b/bucket/wix.json
@@ -5,7 +5,7 @@
     "license": "MS-RL",
     "url": "https://www.nuget.org/api/v2/package/wix/7.0.0#/wix.7.0.0.nupkg1",
     "hash": "7f992e57c356dcbda2ea961bf3b348e1bd7d31d96795be4ac391e04cf140536d",
-    "pre_install": "Expand-7zipArchive -Path \"$dir\\wix.*.nupkg1\" -ExtractDir \"tools\\net6.0\\any\" -Removal",
+    "pre_install": "Expand-7zipArchive -Path \"$dir\\wix.*.nupkg1\" -ExtractDir \"tools\\net8.0\\any\" -Removal",
     "bin": "wix.exe",
     "checkver": {
         "url": "https://www.nuget.org/packages/wix",


### PR DESCRIPTION
Fix `pre_install` script error caused by path change