### PR TITLE
qqnt: Update checkver and urls

### DIFF
--- a/bucket/qqnt.json
+++ b/bucket/qqnt.json
@@ -2,19 +2,19 @@
     "homepage": "https://im.qq.com/pcqq/index.shtml",
     "description": "An instant messaging software service developed by Tencent",
     "license": "Freeware",
-    "version": "9.9.29.260401",
+    "version": "9.9.30.260511",
     "architecture": {
         "64bit": {
-            "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.29_260401_x64_01.exe#/dl.7z",
-            "hash": "d52601a3224d29364f03f4948a487ecd2710db1921383730801d795397e0a808"
+            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.30/guanwang/6a035910/QQ_9.9.30-260511_x64_01.exe#/dl.7z",
+            "hash": "d32e291a220b9461697153be91a99a2b6f169ed33deb74a6de87d4770c8a32b3"
         },
         "32bit": {
-            "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.29_260401_x86_01.exe#/dl.7z",
-            "hash": "7b36370844a6f449389eab73953269d3dd9314d67f078d48987bfcfefee13887"
+            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.30/guanwang/6a035910/QQ_9.9.30-260511_x86_01.exe#/dl.7z",
+            "hash": "113bf9e4c3b98a101ca869caf1a00414bd2acdc2dd09db854667b2d3e3cc8116"
         },
         "arm64": {
-            "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_9.9.29_260401_arm64_01.exe#/dl.7z",
-            "hash": "9093d23c99cf337ee6c40a2faf2d339c9299e567133d2e30bd159981f46fd6a9"
+            "url": "https://qqdl.gtimg.cn/qqfile/QQNT/9.9.30/guanwang/6a035910/QQ_9.9.30_260511_arm64_01.exe#/dl.7z",
+            "hash": "9921311876b5f24e93036a130a76dec442dd6c8a66f58a7809ae8b1de6f942cc"
         }
     },
     "extract_dir": "Files",
@@ -25,34 +25,20 @@
         ]
     ],
     "checkver": {
-        "script": [
-            "$check_regex = [regex]\"QQNT\\/Windows\\/QQ_([\\d.]+)_([\\d]+)_x64_01\\.exe\"",
-            "$check_url = \"https://cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/windowsConfig.js\"",
-            "$check_page = Invoke-WebRequest -Uri $check_url -UseBasicParsing | Select-Object -ExpandProperty Content",
-            "$check_page -match $check_regex",
-            "$fetch_version_head = $matches[1]",
-            "$fetch_version_tail = $matches[2]",
-            "$fetch_version = ($fetch_version_head, $fetch_version_tail) -Join \".\"",
-            "$current_version_tail = $json.version -Split \"\\.\" | Select-Object -Last 1",
-            "if ([int]$fetch_version_tail -ge [int]$current_version_tail) {",
-            "    return $fetch_version",
-            "} else {",
-            "    Write-Warning \"[TencentQQNT] Fetched latest version: $fetch_version, aborting update...\"",
-            "    return $json.version",
-            "}"
-        ],
-        "regex": "([\\d.]+)"
+        "url": "https://im.qq.com/proxy/domain/cdn-go.cn/qq-web/im.qq.com_new/latest/rainbow/pcConfig.json",
+        "regex": "Windows\":{\"version\":\"([\\d.]+)\",\"updateDate\":\"20([\\d]+)-([\\d]+)-([\\d]+)\".*gtimg\\.cn\\/([\\w\\-\\/.]+x86_01.exe)\".*gtimg\\.cn\\/([\\w\\-\\/.]+x64_01.exe)\".*gtimg\\.cn\\/([\\w\\-\\/.]+arm64_01.exe)\"",
+        "replace": "${1}.${2}${3}${4}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_$matchHead_$buildVersion_x64_01.exe#/dl.7z"
+                "url": "https://qqdl.gtimg.cn/$match6#/dl.7z"
             },
             "32bit": {
-                "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_$matchHead_$buildVersion_x86_01.exe#/dl.7z"
+                "url": "https://qqdl.gtimg.cn/$match5#/dl.7z"
             },
             "arm64": {
-                "url": "https://dldir1v6.qq.com/qqfile/qq/QQNT/Windows/QQ_$matchHead_$buildVersion_arm64_01.exe#/dl.7z"
+                "url": "https://qqdl.gtimg.cn/$match7#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Tencent updated release page and download url for qqnt, the [roll-back issue](https://github.com/chawyehsu/dorado/issues/1041) seems solved now.

Closes #1041 