### PR TITLE
micromamba: Add reverse: true to the checkver configuration, and update the download url to 2.6.2-1

### DIFF
--- a/bucket/micromamba.json
+++ b/bucket/micromamba.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://github.com/mamba-org/mamba",
     "description": "Micromamba is a tiny version of mamba, the fast conda package installer.",
-    "version": "2.6.1-0",
+    "version": "2.6.2-1",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mamba-org/micromamba-releases/releases/download/2.6.1-0/micromamba-win-64#/micromamba.exe",
-            "hash": "ce94555ed8ba0ac4eb6a0fbaab16ddca152400c5278363632c7d0600b7fa3333"
+            "url": "https://github.com/mamba-org/micromamba-releases/releases/download/2.6.2-1/micromamba-win-64#/micromamba.exe",
+            "hash": "af63b3c3061aa150bf520a59f3ebce3a8d10ae730f624872b1cfe3997dd803c9"
         }
     },
     "post_install": "New-Item -Path \"$dir\\base\" -ItemType Directory -Force | Out-Null",
@@ -16,7 +16,8 @@
     },
     "checkver": {
         "url": "https://api.anaconda.org/release/conda-forge/micromamba/latest",
-        "regex": "win-64/micromamba-([\\d.]+([\\w-]+)).tar.bz2"
+        "regex": "win-64/micromamba-([\\d.]+([\\w-]+)).tar.bz2",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Add `"reverse": true` to `checkver` to prevent matching the non-existent 2.6.2-0 version.
- Update URLs in autoupdate
- Update to latest version

<img width="1528" height="391" alt="PixPin_2026-05-26_23-38-41" src="https://github.com/user-attachments/assets/d7cdf9db-c2f0-49d6-ae6b-e09c46e3694e" />
