### PR TITLE
todesk: Update scripts for new file structures in app installer

### DIFF
--- a/bucket/todesk.json
+++ b/bucket/todesk.json
@@ -8,10 +8,10 @@
         "script": [
             "$package_archive = if ($architecture -eq '64bit') {'app64.7z'} else {'app32.7z'}",
             "Expand-7zipArchive -Path \"$dir\\$package_archive\" -DestinationPath \"$dir\"",
-            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\app*.7z\", \"$dir\\uninst.exe\" -Force -Recurse",
+            "Remove-Item -Path \"$dir\\`$PLUGINSDIR\", \"$dir\\app*.7z\", \"$dir\\uninst.exe\" -Force -Recurse",
             "if (-not (Test-Path \"$persist_dir\\config.ini\")) {",
-            "    $ini_config = \"[ConfigInfo]`nautoStart=0\"",
-            "    $ini_config | Out-File -FilePath \"$dir\\config.ini\" -Encoding UTF8",
+            "    $initial_config = \"[ConfigInfo]`nautoStart=0\"",
+            "    $initial_config | Out-File -FilePath \"$dir\\config.ini\" -Encoding UTF8",
             "}"
         ]
     },

--- a/bucket/todesk.json
+++ b/bucket/todesk.json
@@ -1,15 +1,20 @@
 {
-    "homepage": "https://www.todesk.com/",
-    "description": "A unlimited speed multifunctional remote control software",
     "version": "nightly",
+    "description": "A unlimited speed multifunctional remote control software",
+    "homepage": "https://www.todesk.com/",
     "license": "Proprietary",
     "url": "https://dl.todesk.com/windows/ToDesk_Setup.exe#/dl.7z",
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\config.ini\")) {",
-        "    New-Item -Force -Path \"$persist_dir\\config.ini\" -ItemType File -Value \"[ConfigInfo]`nautoStart=0\" | Out-Null",
-        "}"
-    ],
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\",\"$dir\\uninst.exe\" -Force -Recurse",
+    "installer": {
+        "script": [
+            "$package_archive = if ($architecture -eq '64bit') {'app64.7z'} else {'app32.7z'}",
+            "Expand-7zipArchive -Path \"$dir\\$package_archive\" -DestinationPath \"$dir\"",
+            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\app*.7z\", \"$dir\\uninst.exe\" -Force -Recurse",
+            "if (-not (Test-Path \"$persist_dir\\config.ini\")) {",
+            "    $ini_config = \"[ConfigInfo]`nautoStart=0\"",
+            "    $ini_config | Out-File -FilePath \"$dir\\config.ini\" -Encoding UTF8",
+            "}"
+        ]
+    },
     "shortcuts": [
         [
             "ToDesk.exe",

--- a/bucket/todesk.json
+++ b/bucket/todesk.json
@@ -10,8 +10,8 @@
             "Expand-7zipArchive -Path \"$dir\\$package_archive\" -DestinationPath \"$dir\"",
             "Remove-Item -Path \"$dir\\`$PLUGINSDIR\", \"$dir\\app*.7z\", \"$dir\\uninst.exe\" -Force -Recurse",
             "if (-not (Test-Path \"$persist_dir\\config.ini\")) {",
-            "    $initial_config = \"[ConfigInfo]`nautoStart=0\"",
-            "    $initial_config | Out-File -FilePath \"$dir\\config.ini\" -Encoding UTF8",
+            "    $initial_config = \"[ConfigInfo]`nautoStart=0`nautoupdate=0`n\"",
+            "    New-Item -Force -Path \"$dir\\config.ini\" -ItemType File -Value $initial_config | Out-Null",
             "}"
         ]
     },


### PR DESCRIPTION
- Fix installer script error due to installer structures changing
- Reorder fields according to the [scoop guidelines](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md#for-scoop-buckets)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/chawyehsu/dorado/pull/1050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->