### PR TITLE
pixpin: Update checkver

### DIFF
--- a/bucket/pixpin.json
+++ b/bucket/pixpin.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.2.3.1",
+    "version": "3.4.3.2",
     "description": "Screenshots, screen recording, OCR tool.",
     "homepage": "https://pixpin.cn/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.pixpin.cn/PixPin_cn_zh-cn_3.2.3.1.zip#/dl.zip",
-            "hash": "52f469aa83d8f6bf8615cb68b9afb95f22d7c766dc513471c8f14bf39801be31"
+            "url": "https://down.pixpin.cn/PixPin_win_3.4.3.2.zip#/dl.zip",
+            "hash": "1ed2b048f7e1468cdd3dc869c3db0653d9308ffe4f48fb42091b0b559a90b211"
         }
     },
     "extract_dir": "PixPin",
@@ -36,14 +36,12 @@
     ],
     "checkver": {
         "url": "https://pixpin.cn/download/",
-        "regex": "(PixPin[a-zA-Z0-9_.-]+_(\\d+(?:\\.\\d+)*)\\.zip)",
-        "replace": "$2",
-        "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+        "regex": "PixPin_win_(\\d+(?:\\.\\d+)*)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://down.pixpin.cn/$match1#/dl.zip"
+                "url": "https://down.pixpin.cn/PixPin_win_$version.zip#/dl.zip"
             }
         }
     }

--- a/bucket/pixpin.json
+++ b/bucket/pixpin.json
@@ -37,7 +37,8 @@
     "checkver": {
         "url": "https://pixpin.cn/download/",
         "regex": "(PixPin[a-zA-Z0-9_.-]+_(\\d+(?:\\.\\d+)*)\\.zip)",
-        "replace": "$2"
+        "replace": "$2",
+        "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/pixpin.json
+++ b/bucket/pixpin.json
@@ -36,12 +36,13 @@
     ],
     "checkver": {
         "url": "https://pixpin.cn/download/",
-        "regex": "PixPin_cn_zh-cn_(\\d+(?:\\.\\d+)*)"
+        "regex": "(PixPin[a-zA-Z0-9_.-]+_(\\d+(?:\\.\\d+)*)\\.zip)",
+        "replace": "$2"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.pixpin.cn/PixPin_cn_zh-cn_$version.zip#/dl.zip"
+                "url": "https://down.pixpin.cn/$match1#/dl.zip"
             }
         }
     }


### PR DESCRIPTION
**What's the problem**  
The upstream changed the Windows download filename format from `PixPin_cn_zh-cn_$version.zip` to `PixPin_win_$version.zip`. This breaks current `checkver`, preventing Scoop from detecting new versions

**How to fix**  
Update the `checkver` regex to `(PixPin[a-zA-Z0-9_.-]+_(\d+(?:\.\d+)*)\.zip)`:
- The outer group catches the full filename. The `[a-zA-Z0-9_.-]+` part keeps it flexible in case the naming gets tweaked slightly in the future.
- The inner group cleanly extracts just the version number (e.g., `x.x.x.x`).
- Added `replace: "$2"` so Scoop only uses the version number for updates, rather than the whole filename.

**Other changes**  
1. Updated `autoupdate.architecture.64bit.url` to build the download link dynamically using the matched full filename, making sure it grabs the right file going forward.
2. Synced the download domain from `download.pixpin.cn` to `down.pixpin.cn` to match the upstream. *(The old domain still works fine with the new filename, but I think it's better to stick to the new one).*
3. Added an explicit Windows `checkver.useragent`. Even though the default Scoop UA (`Scoop/1.0 (+http://scoop.sh/)`) still happens to return the Windows version right now, setting it explicitly just keeps things reliable.

Fixes #1053