### PR TITLE
axure: Fix download URL

### DIFF
--- a/bucket/axure.json
+++ b/bucket/axure.json
@@ -3,7 +3,7 @@
     "description": "Prototypes, Specifications, and Diagrams in One Tool",
     "version": "11.0.0.4137",
     "license": "Proprietary",
-    "url": "https://axure.cachefly.net/versions/11-0/AxureRP-Setup-4137.exe#/installer.exe",
+    "url": "https://d3uii9pxdigrx1.cloudfront.net/AxureRP-Setup.exe#/installer.exe",
     "hash": "783be584d1f2b757e1fcc6dad285545e027b7110aa7430e1992246b4ece37500",
     "depends": "dark",
     "installer": {
@@ -28,6 +28,6 @@
         "regex": "Axure RP ([\\d.]+) for Windows"
     },
     "autoupdate": {
-        "url": "https://axure.cachefly.net/versions/$majorVersion-$minorVersion/AxureRP-Setup-$buildVersion.exe#/installer.exe"
+        "url": "https://d3uii9pxdigrx1.cloudfront.net/AxureRP-Setup.exe#/installer.exe"
     }
 }


### PR DESCRIPTION
Updates Axure to use the current official Windows download URL.

Checks:
- bucket tests
- checkver
- checkurls
- checkhashes

Closes #1035
