### PR TITLE
aliyundrive: restore official download URL

### DIFF
--- a/bucket/aliyundrive.json
+++ b/bucket/aliyundrive.json
@@ -6,7 +6,7 @@
         "identifier": "EULA",
         "url": "https://www.alipan.com/protocol/service"
     },
-    "url": "https://dorado-api.deno.dev/alipan?version=6.9.3&dl#/aDrive-6.9.3.7z",
+    "url": "https://cdn.aliyundrive.net/downloads/apps/desktop/aDrive-6.9.3.exe#/aDrive-6.9.3.7z",
     "hash": "3ccbdfa920528bd0295c1197a84bcd552cc1cfe2bf2ad722ace7d5dd93bdb281",
     "post_install": [
         "@('$PLUGINSDIR', '$TEMP') | ForEach-Object {",
@@ -20,10 +20,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://dorado-api.deno.dev/alipan",
-        "jsonpath": "$.version"
+        "url": "https://www.alipan.com/download",
+        "regex": "aDrive-([\\d.]+)\\.exe"
     },
     "autoupdate": {
-        "url": "https://dorado-api.deno.dev/alipan?version=$version&dl#/aDrive-$version.7z"
+        "url": "https://cdn.aliyundrive.net/downloads/apps/desktop/aDrive-$version.exe#/aDrive-$version.7z"
     }
 }


### PR DESCRIPTION
## Summary

- replace the unavailable `dorado-api.deno.dev` download endpoint with Aliyun Drive's official CDN
- read the current version from the official Alipan download page
- update the autoupdate URL to use the same official CDN

## Validation

- confirmed the official `aDrive-6.9.3.exe` URL returns the expected 150,630,960-byte file
- confirmed its SHA-256 is `3ccbdfa920528bd0295c1197a84bcd552cc1cfe2bf2ad722ace7d5dd93bdb281`, matching the existing manifest hash
- confirmed the new checkver expression detects version `6.9.3`
- parsed the manifest as JSON and ran `git diff --check`

Full bucket tests were not run locally because the available Pester version is older than the repository's required 4.4.0.

Fixes #1055

AI assistance: Codex was used to help investigate and prepare this change.