### PR TITLE
utools: Update installation progress and checkver regex

### DIFF
--- a/bucket/utools.json
+++ b/bucket/utools.json
@@ -1,34 +1,45 @@
 {
-    "homepage": "https://u.tools/",
-    "description": "Your productive tools set and launcher.",
-    "license": "Proprietary",
     "version": "7.8.0",
+    "description": "Your productive tools set and launcher.",
+    "homepage": "https://u.tools/",
+    "license": "Proprietary",
     "architecture": {
         "64bit": {
             "url": "https://open.u-tools.cn/download/uTools-7.8.0.exe#/dl.7z",
-            "hash": "1a1fea20a10dc2a691be272e4082c80e0dc7dc032e66696ab8ddf0c7a81aabe4",
-            "installer": {
-                "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR/app-64.7z\" \"$dir\""
-            }
+            "hash": "1a1fea20a10dc2a691be272e4082c80e0dc7dc032e66696ab8ddf0c7a81aabe4"
         },
         "32bit": {
             "url": "https://open.u-tools.cn/download/uTools-7.8.0-ia32.exe#/dl.7z",
-            "hash": "cb8644f2d8dcbf42a3fe3cab946b37cb61b1d7a4062f1bb185723881071adf00",
-            "installer": {
-                "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR/app-32.7z\" \"$dir\""
-            }
+            "hash": "cb8644f2d8dcbf42a3fe3cab946b37cb61b1d7a4062f1bb185723881071adf00"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$R0\" -Force -Recurse",
+    "extract_dir": "$PLUGINSDIR",
+    "installer": {
+        "script": [
+            "$packageFile = if ($architecture -eq '64bit') { [string] 'app-64.7z' } else { [string] 'app-32.7z' }",
+            "Remove-Item \"$dir\\*\" -Exclude \"$packageFile\"",
+            "Expand-7zipArchive \"$dir\\$packageFile\" \"$dir\" -Removal",
+            "Import-Module $(Join-Path $(Find-BucketDirectory -Root -Name dorado) scripts/DoradoUtils.psm1)",
+            "Mount-ExternalRuntimeData -Source \"$persist_dir\\uTools\" -Target \"$env:APPDATA\\uTools\"",
+            "Remove-Module -Name DoradoUtils"
+        ]
+    },
     "shortcuts": [
         [
             "uTools.exe",
             "uTools"
         ]
     ],
+    "uninstaller": {
+        "script": [
+            "Import-Module $(Join-Path $(Find-BucketDirectory -Root -Name dorado) scripts/DoradoUtils.psm1)",
+            "Dismount-ExternalRuntimeData -Target \"$env:APPDATA\\uTools\"",
+            "Remove-Module -Name DoradoUtils"
+        ]
+    },
     "checkver": {
         "url": "https://www.u-tools.cn/download/",
-        "regex": "/download/uTools-([\\d.]+).exe"
+        "regex": "v<[\\!\\-\\s]+>([\\d.]+)<"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This PR primarily updates installation processes and checkver regex of utools, the app should properly expand to app directory with this manifest, it meets some of the requests in #1016.
However, the app itself keeps not working with a portable installation, at least a registry file is required to enable the functionality, or just port to non-portable version.

Closes #1016