### PR TITLE
synapse: Add v0.1.43

### DIFF
--- a/bucket/synapse.json
+++ b/bucket/synapse.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.1.43",
+  "description": "Local coding agent built on LangChain Deep Agents (LocalShell, no sandbox)",
+  "homepage": "https://github.com/alex8224/synapse-agent",
+  "license": "Apache-2.0",
+  "bin": [
+    ["synapse-windows-x64.exe", "synapse"]
+  ],
+  "checkver": {
+    "github": "https://github.com/alex8224/synapse-agent"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/alex8224/synapse-agent/releases/download/v0.1.43/synapse-windows-x64.exe",
+      "hash": "c1fcc815af508e1051440dd944dc735ce1102e98b71e4cea40f3cdd31bababd3"
+    }
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/alex8224/synapse-agent/releases/download/v$version/synapse-windows-x64.exe",
+        "hash": {
+          "url": "$baseurl/synapse-windows-x64.exe.sha256",
+          "mode": "extract"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a new manifest for Synapse, a terminal-first coding agent.

- Portable single-file Windows x64 build (PyInstaller): no installer, no admin.
- Apache-2.0 license.
- checkver from GitHub releases (v-prefixed tags).
- autoupdate downloads the exe and extracts SHA-256 from the \.sha256\ asset published alongside each release.
- Installs a \synapse\ shim for the TUI entry point.

https://github.com/alex8224/synapse-agent