### PR TITLE
cloudflare-speedtest: Fix alias argument error

### DIFF
--- a/bucket/cloudflare-speedtest.json
+++ b/bucket/cloudflare-speedtest.json
@@ -3,7 +3,7 @@
     "description": "Test Cloudflare CDN latency and speed to get the fastest IP!",
     "homepage": "https://github.com/XIU2/CloudflareSpeedTest",
     "license": "GPL-3.0-only",
-    "notes": "cloudflarest-ip: load the default ip files(ip.txt & ipv6.txt) to perform speed test",
+    "notes": "cfst-ip: load the default ip files(ip.txt & ipv6.txt) to perform speed test",
     "architecture": {
         "64bit": {
             "url": "https://github.com/XIU2/CloudflareSpeedTest/releases/download/v2.3.5/cfst_windows_amd64.zip",
@@ -22,6 +22,7 @@
         "cfst.exe",
         [
             "cfst.exe",
+            "cfst-ip",
             "-f",
             "$dir\\ip.txt",
             "-f",


### PR DESCRIPTION
The second item in the array is an alias. It was mistakenly removed in #1047, so restore it.
